### PR TITLE
Closes #94: Fixing linting errors for backend

### DIFF
--- a/telos-backend/.eslintrc.js
+++ b/telos-backend/.eslintrc.js
@@ -15,5 +15,6 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-uses-react': 'off',
     'func-names': 'off',
+    'no-console': 'off',
   },
 };

--- a/telos-backend/app.js
+++ b/telos-backend/app.js
@@ -7,6 +7,7 @@ const port = process.env.PORT || 3001;
 app.use(express.json());
 
 const router = require('./src/routes');
+
 app.use('/', router);
 
 // Basic message for verifying Express app is working

--- a/telos-backend/package.json
+++ b/telos-backend/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "node app.js",
     "test": "jest",
-    "pretty": "prettier --write \"./**/*.{js,jsx,json}\"",
-    "lint": "eslint \"./**/*.{js,jsx,json}\""
+    "pretty": "prettier --write \"./**/*.{js,jsx}\"",
+    "lint": "eslint \"./**/*.{js,jsx}\""
   },
   "author": "",
   "license": "ISC",

--- a/telos-backend/src/models/todos.js
+++ b/telos-backend/src/models/todos.js
@@ -1,3 +1,1 @@
-const mongoose = require('mongoose');
-
 // Placeholder for todos schema

--- a/telos-backend/src/routes/api/index.js
+++ b/telos-backend/src/routes/api/index.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 // Add in the other routers here:
 // eg. const todos = require('./todos')
-//router.use('/todos', todos)
+// router.use('/todos', todos)
 
 // Test end point to verify the router paths work.
 router.get('/', (req, res) => {

--- a/telos-backend/src/routes/index.js
+++ b/telos-backend/src/routes/index.js
@@ -4,6 +4,7 @@ const router = express.Router();
 
 // Import the exported router from api/index.js
 const apiRouter = require('./api');
+
 router.use('/api', apiRouter);
 
 module.exports = router;


### PR DESCRIPTION
Closes #94 

Fixed and updated linting rules to ensure github actions are working as expected.

Removed the no-console rule so logging for backend servers can be done. 
Removed parsing JSON, as eslint is designed for Javascript files. 