### PR TITLE
add dashboard calendar design

### DIFF
--- a/telos-frontend/package.json
+++ b/telos-frontend/package.json
@@ -9,7 +9,9 @@
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.3",
     "fontsource-roboto": "^4.0.0",
+    "moment": "^2.29.1",
     "react": "^17.0.1",
+    "react-big-calendar": "^0.33.2",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.1.1"

--- a/telos-frontend/src/components/calendar/DashboardCalendar.jsx
+++ b/telos-frontend/src/components/calendar/DashboardCalendar.jsx
@@ -1,3 +1,36 @@
-const DashboardCalendar = () => <div />;
+import { Calendar, momentLocalizer } from 'react-big-calendar';
+import moment from 'moment';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import './react-big-calendar.css';
+
+const localizer = momentLocalizer(moment);
+
+const events = [
+  {
+    id: 14,
+    title: 'Today',
+    start: new Date(new Date().setHours(new Date().getHours() - 3)),
+    end: new Date(new Date().setHours(new Date().getHours() + 1)),
+  },
+  {
+    id: 23,
+    title: 'Go to the gym 💪',
+    start: new Date(new Date().setHours(new Date().getHours() - 3)),
+    end: new Date(new Date().setHours(new Date().getHours() + 5)),
+  },
+];
+
+const DashboardCalendar = () => (
+  <div>
+    <Calendar
+      selectable
+      localizer={localizer}
+      events={events}
+      startAccessor="start"
+      endAccessor="end"
+      style={{ height: window.screen.height - 110, width: '100%' }}
+    />
+  </div>
+);
 
 export default DashboardCalendar;

--- a/telos-frontend/src/components/calendar/react-big-calendar.css
+++ b/telos-frontend/src/components/calendar/react-big-calendar.css
@@ -1,0 +1,16 @@
+.rbc-today {
+  background-color: #dbc7ff;
+}
+
+.rbc-event,
+.rbc-day-slot .rbc-background-event {
+  background-color: #590de5;
+}
+.rbc-event.rbc-selected,
+.rbc-day-slot .rbc-selected.rbc-background-event {
+  background-color: #4609b5;
+}
+.rbc-event:focus,
+.rbc-day-slot .rbc-background-event:focus {
+  outline: 5px auto #620dfc;
+}


### PR DESCRIPTION
## Proposed Changes
**This PR is with reference to the issue https://github.com/UOA-SE701-Group3-2021/3Lancers/issues/80.**
- Added the basic design for the dashboard calendar view.
- Changed default css to match the app's design.

**Here are some screenshots of the widget:** 
<img width="1440" alt="Screen Shot 2021-03-20 at 12 27 36 PM" src="https://user-images.githubusercontent.com/44574494/111851381-cd18cc00-8977-11eb-8be6-53c09af89fcc.png">
<img width="1440" alt="Screen Shot 2021-03-20 at 12 27 45 PM" src="https://user-images.githubusercontent.com/44574494/111851387-d1dd8000-8977-11eb-8eb6-951d8c66361d.png">
<img width="1440" alt="Screen Shot 2021-03-20 at 12 28 05 PM" src="https://user-images.githubusercontent.com/44574494/111851388-d30ead00-8977-11eb-9191-20ae8e9377d7.png">
