### PR TITLE
Closes #73: Configuration for connecting to local MongoDB instance using Mongoose

### DIFF
--- a/telos-backend/app.js
+++ b/telos-backend/app.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const mongoose = require('mongoose');
 
 // Setup Express and assign it a port (cannot be same as CRA default port)
 const app = express();
@@ -12,6 +13,21 @@ app.use('/', router);
 
 // Basic message for verifying Express app is working
 app.get('/', (req, res) => res.send('Telos app coming soon!'));
+
+// Connect to local running instance of mongodb, on telosdatabase db
+// useNewUrlParser recommended set to true, but must specify a port (using the default 27017)
+// useUnifiedTopology recommended set to true (uses mongodb new connection management engine)
+mongoose.connect('mongodb://localhost:27017/telosdatabase', {
+    useNewUrlParser: true, 
+    useUnifiedTopology: true
+});
+const db = mongoose.connection;
+
+// Callbacks to verify we have connected correctly, or when a connection error occurs
+db.on('error', console.error.bind(console, 'connection error:'));
+db.once('open', () => {
+  console.log('Connected to local database');
+});
 
 // Launch app (start server running), with a simple logging statement, based on SE750 example
 app.listen(port, () => console.log(`App server litening on port number: ${port}`));


### PR DESCRIPTION
Closes #73 

## Proposed Changes
Using mongoose, we can connect to a locally running instance of MongoDB to be able to persist changes and demonstrate that our app can use a scalable data store. 

Note:
In order for the backend sever to run, this now requires a instance of MongoDB to be running locally. Installation instructions can be [found here](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#procedure), and the [configuration instructions are here](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#procedure)
Basic notes if you're on Windows:
- If you're on windows, install via the .msi, and go through the install instructions. You probably don't want to install it as a service (this would run in the background permanently).
- Once its installed, you'll need to follow the config instructions, main point is that it requires a `data\db` folder in the C: drive 
- Then run the following command from a cmd instance (don't use powershell in VSCode, go through windows search and open up command prompt/cmd.exe), assuming you didn't change the location of where its installed: `"C:\Program Files\MongoDB\Server\4.4\bin\mongod.exe" --dbpath="c:\data\db"`

This information will be captured in the backend documentation at a later stage.

There are no tests in this PR, as this is interacting with a different program, but testing was done by ensuring the "Connected to local database" log message turned up, and that there was a connection as seen in the logs of the mongod instance: 
![ConnectionAccepted](https://user-images.githubusercontent.com/49116468/111582766-2968d800-8820-11eb-8e90-06cac5a8a7f9.png)

