### PR TITLE
Closes #41: Initial configuration for in-memory databases for testing purposes

### DIFF
--- a/telos-backend/.eslintrc.js
+++ b/telos-backend/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
     'react/jsx-uses-react': 'off',
     'func-names': 'off',
     'no-console': 'off',
+    'no-underscore-dangle': 'off',
   },
 };

--- a/telos-backend/app.js
+++ b/telos-backend/app.js
@@ -18,8 +18,8 @@ app.get('/', (req, res) => res.send('Telos app coming soon!'));
 // useNewUrlParser recommended set to true, but must specify a port (using the default 27017)
 // useUnifiedTopology recommended set to true (uses mongodb new connection management engine)
 mongoose.connect('mongodb://localhost:27017/telosdatabase', {
-    useNewUrlParser: true, 
-    useUnifiedTopology: true
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
 });
 const db = mongoose.connection;
 

--- a/telos-backend/package-lock.json
+++ b/telos-backend/package-lock.json
@@ -915,6 +915,12 @@
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
     },
+    "@types/tmp": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
+      "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.13",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
@@ -985,6 +991,32 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -1392,6 +1424,12 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1512,6 +1550,22 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1771,6 +1825,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -3664,6 +3724,15 @@
         "bser": "2.1.1"
       }
     },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -3703,6 +3772,23 @@
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
+    },
+    "find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
+    "find-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+      "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
+      "dev": true
     },
     "find-up": {
       "version": "4.1.0",
@@ -3772,6 +3858,12 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3823,6 +3915,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "dev": true
     },
     "get-stream": {
@@ -4062,6 +4160,33 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -4075,6 +4200,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -5319,6 +5450,15 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "dev": true,
+      "requires": {
+        "signal-exit": "^3.0.2"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -5392,6 +5532,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "md5-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
+      "integrity": "sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -5513,6 +5659,128 @@
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
+      }
+    },
+    "mongodb-memory-server": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.9.6.tgz",
+      "integrity": "sha512-BjGPPh5f61lMueG7px9DneBIrRR/GoWUHDvLWVAXhQhKVcwMMXxgeEba6zdDolZHfYAu6aYGPzhOuYKIKPgpBQ==",
+      "dev": true,
+      "requires": {
+        "mongodb-memory-server-core": "6.9.6"
+      }
+    },
+    "mongodb-memory-server-core": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.9.6.tgz",
+      "integrity": "sha512-ZcXHTI2TccH3L5N9JyAMGm8bbAsfLn8SUWOeYGHx/vDx7vu4qshyaNXTIxeHjpUQA29N+Z1LtTXA6vXjl1eg6w==",
+      "dev": true,
+      "requires": {
+        "@types/tmp": "^0.2.0",
+        "camelcase": "^6.0.0",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.2.0",
+        "find-cache-dir": "^3.3.1",
+        "find-package-json": "^1.2.0",
+        "get-port": "^5.1.1",
+        "https-proxy-agent": "^5.0.0",
+        "lockfile": "^1.0.4",
+        "md5-file": "^5.0.0",
+        "mkdirp": "^1.0.4",
+        "mongodb": "^3.6.2",
+        "semver": "^7.3.2",
+        "tar-stream": "^2.1.4",
+        "tmp": "^0.2.1",
+        "uuid": "^8.3.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "mongoose": {
@@ -6070,6 +6338,12 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -7367,6 +7641,51 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -7762,8 +8081,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -8015,6 +8333,16 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/telos-backend/package.json
+++ b/telos-backend/package.json
@@ -9,6 +9,9 @@
     "pretty": "prettier --write \"./**/*.{js,jsx}\"",
     "lint": "eslint \"./**/*.{js,jsx}\""
   },
+  "jest": {
+    "testEnvironment": "node"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -17,7 +20,6 @@
     "nodemon": "^2.0.7"
   },
   "devDependencies": {
-    "jest": "^26.6.3",
     "eslint": "^7.22.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-node": "^4.1.0",
@@ -28,6 +30,8 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "jest": "^26.6.3",
+    "mongodb-memory-server": "^6.9.6",
     "prettier": "^2.2.1"
   }
 }

--- a/telos-backend/test/db-helper.js
+++ b/telos-backend/test/db-helper.js
@@ -7,25 +7,25 @@ const mongoProcess = new MongoMemoryServer();
 // Connect to the in-memory database. When requiring this file, a process will already
 // have started. Ensure to disconnect using closeDb.
 module.exports.connectToDb = async () => {
-    const uri = await mongoProcess.getUri();
-    await mongoose.connect(uri, {
-       useNewUrlParser: true,
-       useUnifiedTopology: true, 
-    });
-}
+  const uri = await mongoProcess.getUri();
+  await mongoose.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+};
 
-// Drop all mongoose connections, then stop the running process. 
-// Use to clean up after all tests. 
+// Drop all mongoose connections, then stop the running process.
+// Use to clean up after all tests.
 module.exports.closeDb = async () => {
-    await mongoose.disconnect();
-    await mongoProcess.stop();
-}
+  await mongoose.disconnect();
+  await mongoProcess.stop();
+};
 
 // Wipe data from db without disconnecting/ending the process.
 module.exports.clearDb = async () => {
-    const allCollections = mongoose.connection.collections;
-    for (const index in allCollections) {
-        const collection = allCollections[index];
-        await collection.deleteMany();
-    }
-}
+  const allCollections = mongoose.connection.collections;
+  for (const index in allCollections) {
+    const collection = allCollections[index];
+    await collection.deleteMany();
+  }
+};

--- a/telos-backend/test/db-helper.js
+++ b/telos-backend/test/db-helper.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mongoProcess = new MongoMemoryServer();
+
+// Connect to the in-memory database. When requiring this file, a process will already
+// have started. Ensure to disconnect using closeDb.
+module.exports.connectToDb = async () => {
+    const uri = await mongoProcess.getUri();
+    await mongoose.connect(uri, {
+       useNewUrlParser: true,
+       useUnifiedTopology: true, 
+    });
+}
+
+// Drop all mongoose connections, then stop the running process. 
+// Use to clean up after all tests. 
+module.exports.closeDb = async () => {
+    await mongoose.disconnect();
+    await mongoProcess.stop();
+}
+
+// Wipe data from db without disconnecting/ending the process.
+module.exports.clearDb = async () => {
+    const allCollections = mongoose.connection.collections;
+    for (const index in allCollections) {
+        const collection = allCollections[index];
+        await collection.deleteMany();
+    }
+}

--- a/telos-backend/test/db-helper.js
+++ b/telos-backend/test/db-helper.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop, no-restricted-syntax, guard-for-in */
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 

--- a/telos-backend/test/unit.test.js
+++ b/telos-backend/test/unit.test.js
@@ -11,29 +11,29 @@ afterAll(async () => await dbHelper.closeDb());
 
 // A test model to demonstrate if it works or not
 const testSchema = new mongoose.Schema({
-    name: { 
-        type: String,
-        required: true,
-    },
-    startTime: {
-        type: Date,
-        required: true,
-    },
+  name: {
+    type: String,
+    required: true,
+  },
+  startTime: {
+    type: Date,
+    required: true,
+  },
 });
 const TestModel = mongoose.model('TestModel', testSchema);
 
 describe('test schema creation', () => {
-    it('can be created and save in memory', async () => {
-        const testData = {
-            name: 'Test event',
-            startTime: "2021-01-01"
-        };
-        const validTestData = new TestModel(testData);
-        const savedTestModel = await validTestData.save();
+  it('can be created and save in memory', async () => {
+    const testData = {
+      name: 'Test event',
+      startTime: '2021-01-0Dasdfsaf',
+    };
+    const validTestData = new TestModel(testData);
+    const savedTestModel = await validTestData.save();
 
-        expect(savedTestModel.name).toBe(validTestData.name)
-        expect(savedTestModel.startTime).toBe(validTestData.startTime)
+    expect(savedTestModel.name).toBe(validTestData.name);
+    expect(savedTestModel.startTime).toBe(validTestData.name);
 
-        expect(savedTestModel._id).toBeDefined();
-    });
+    expect(savedTestModel._id).toBeDefined();
+  });
 });

--- a/telos-backend/test/unit.test.js
+++ b/telos-backend/test/unit.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop, no-return-await */
 const mongoose = require('mongoose');
 const dbHelper = require('./db-helper');
 // Require the models from src/models

--- a/telos-backend/test/unit.test.js
+++ b/telos-backend/test/unit.test.js
@@ -26,13 +26,13 @@ describe('test schema creation', () => {
   it('can be created and save in memory', async () => {
     const testData = {
       name: 'Test event',
-      startTime: '2021-01-0Dasdfsaf',
+      startTime: '2021-01-01',
     };
     const validTestData = new TestModel(testData);
     const savedTestModel = await validTestData.save();
 
     expect(savedTestModel.name).toBe(validTestData.name);
-    expect(savedTestModel.startTime).toBe(validTestData.name);
+    expect(savedTestModel.startTime).toBe(validTestData.startTime);
 
     expect(savedTestModel._id).toBeDefined();
   });

--- a/telos-backend/test/unit.test.js
+++ b/telos-backend/test/unit.test.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose');
+const dbHelper = require('./db-helper');
+// Require the models from src/models
+
+beforeAll(async () => await dbHelper.connectToDb());
+
+afterEach(async () => await dbHelper.clearDb());
+
+afterAll(async () => await dbHelper.closeDb());
+
+// A test model to demonstrate if it works or not
+const testSchema = new mongoose.Schema({
+    name: { 
+        type: String,
+        required: true,
+    },
+    startTime: {
+        type: Date,
+        required: true,
+    },
+});
+const TestModel = mongoose.model('TestModel', testSchema);
+
+describe('test schema creation', () => {
+    it('can be created and save in memory', async () => {
+        const testData = {
+            name: 'Test event',
+            startTime: "2021-01-01"
+        };
+        const validTestData = new TestModel(testData);
+        const savedTestModel = await validTestData.save();
+
+        expect(savedTestModel.name).toBe(validTestData.name)
+        expect(savedTestModel.startTime).toBe(validTestData.startTime)
+
+        expect(savedTestModel._id).toBeDefined();
+    });
+});


### PR DESCRIPTION
Closes #41 

## Proposed Changes
Using `mongodb-memory-server`, we can create a mongodb instance purely in memory, so we can more easily perform unit tests without worrying about affecting a user's database they are running locally, and ensure we can control the pre/post test states more easily.

Additional work that may come out of this is to create an option for the real server to run using an in memory database - this way a developer won't need to have a mongodb instance running in the background, and knows the state is consistent on every startup.

Note: Currently not all linting rules are followed, this is a draft PR to demonstrate the progress and show how a test will work and to receive feedback. Lint fixes will be made before merging.
