### PR TITLE
Closes #35: Implementing /api/calendar end points

### DIFF
--- a/telos-backend/package-lock.json
+++ b/telos-backend/package-lock.json
@@ -1265,6 +1265,14 @@
       "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -3815,6 +3823,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/telos-backend/package.json
+++ b/telos-backend/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.21.1",
     "express": "^4.17.1",
     "mongoose": "^5.12.0",
     "nodemon": "^2.0.7"

--- a/telos-backend/src/routes/api/calendar.js
+++ b/telos-backend/src/routes/api/calendar.js
@@ -14,7 +14,7 @@ router.post('/', async (req, res) => {
     if (err) {
       return res.status(400).json({error: err});
     }
-    res.status(201).json(newCalendarEvent);
+    return res.status(201).json(newCalendarEvent);
   });
 });
 
@@ -38,10 +38,5 @@ router.delete('/:id', async (req, res) => {
     return res.sendStatus(204);
   });
 });
-
-// router.get('/', async (req, res) => {
-//   const calEvents = await CalendarEvent.find();
-//   res.json(calEvents);
-// });
 
 module.exports = router;

--- a/telos-backend/src/routes/api/calendar.js
+++ b/telos-backend/src/routes/api/calendar.js
@@ -12,18 +12,18 @@ router.post('/', async (req, res) => {
 
   await newCalendarEvent.save((err) => {
     if (err) {
-      return res.status(400).json({error: err});
+      return res.status(400).json({ error: err });
     }
     return res.status(201).json(newCalendarEvent);
   });
 });
 
 router.put('/:id', async (req, res) => {
-  const query = {_id: req.params.id };
+  const query = { _id: req.params.id };
 
-  CalendarEvent.findOneAndUpdate(query, req.body, (err) =>{
+  CalendarEvent.findOneAndUpdate(query, req.body, (err) => {
     if (err) {
-      return res.status(400).json({error: err});
+      return res.status(400).json({ error: err });
     }
     return res.sendStatus(204);
   });
@@ -31,9 +31,9 @@ router.put('/:id', async (req, res) => {
 
 router.delete('/:id', async (req, res) => {
   const { id } = req.params;
-  CalendarEvent.deleteOne({ _id: id}, (err) => {
+  CalendarEvent.deleteOne({ _id: id }, (err) => {
     if (err) {
-      return res.status(400).json({error: err});
+      return res.status(400).json({ error: err });
     }
     return res.sendStatus(204);
   });

--- a/telos-backend/src/routes/api/calendar.js
+++ b/telos-backend/src/routes/api/calendar.js
@@ -38,4 +38,9 @@ router.delete('/:id', async (req, res) => {
   res.sendStatus(201);
 });
 
+router.get('/', async (req, res) => {
+  const calEvents = await CalendarEvent.find();
+  res.json(calEvents);
+});
+
 module.exports = router;

--- a/telos-backend/src/routes/api/calendar.js
+++ b/telos-backend/src/routes/api/calendar.js
@@ -1,26 +1,41 @@
 const express = require('express');
+const CalendarEvent = require('../../models/calendar_event');
 
 const router = express.Router();
 
-router.post('/', (req, res) => {
-  res.json({
-    endpoint: '/calendar',
-    request: `POST name: ${req.body.name}, start: ${req.body.start}, end: ${req.body.end}, completed: ${req.body.completed}`,
+router.post('/', async (req, res) => {
+  const newCalendarEvent = new CalendarEvent({
+    name: req.body.name,
+    startTime: req.body.startTime,
+    endTime: req.body.endTime,
   });
+
+  await newCalendarEvent.save();
+  res.status(201).json(newCalendarEvent);
 });
 
-router.put('/:id', (req, res) => {
-  res.json({
-    endpoint: '/calendar',
-    request: `PUT id: ${req.params.id}, start: ${req.body.start}, end: ${req.body.end}, completed: ${req.body.completed}`,
-  });
+router.put('/:id', async (req, res) => {
+  const { id } = req.params;
+  const calEvent = req.body;
+  calEvent._id = id;
+
+  const currentCalEvent = await CalendarEvent.findById(calEvent._id);
+  if (currentCalEvent){
+    currentCalEvent.name = calEvent.name
+    currentCalEvent.startTime = calEvent.startTime
+    currentCalEvent.endTime = calEvent.endTime
+    await currentCalEvent.save();
+
+    res.sendStatus(201);
+  } else {
+    res.sendStatus(404);
+  }
 });
 
-router.delete('/:id', (req, res) => {
-  res.json({
-    endpoint: '/calendar',
-    request: `DELETE id: ${req.params.id}`,
-  });
+router.delete('/:id', async (req, res) => {
+  const { id } = req.params;
+  await CalendarEvent.deleteOne({ _id: id});
+  res.sendStatus(201);
 });
 
 module.exports = router;

--- a/telos-backend/src/routes/api/calendar.js
+++ b/telos-backend/src/routes/api/calendar.js
@@ -10,37 +10,38 @@ router.post('/', async (req, res) => {
     endTime: req.body.endTime,
   });
 
-  await newCalendarEvent.save();
-  res.status(201).json(newCalendarEvent);
+  await newCalendarEvent.save((err) => {
+    if (err) {
+      return res.status(400).json({error: err});
+    }
+    res.status(201).json(newCalendarEvent);
+  });
 });
 
 router.put('/:id', async (req, res) => {
-  const { id } = req.params;
-  const calEvent = req.body;
-  calEvent._id = id;
+  const query = {_id: req.params.id };
 
-  const currentCalEvent = await CalendarEvent.findById(calEvent._id);
-  if (currentCalEvent){
-    currentCalEvent.name = calEvent.name
-    currentCalEvent.startTime = calEvent.startTime
-    currentCalEvent.endTime = calEvent.endTime
-    await currentCalEvent.save();
-
-    res.sendStatus(201);
-  } else {
-    res.sendStatus(404);
-  }
+  CalendarEvent.findOneAndUpdate(query, req.body, (err) =>{
+    if (err) {
+      return res.status(400).json({error: err});
+    }
+    return res.sendStatus(204);
+  });
 });
 
 router.delete('/:id', async (req, res) => {
   const { id } = req.params;
-  await CalendarEvent.deleteOne({ _id: id});
-  res.sendStatus(201);
+  CalendarEvent.deleteOne({ _id: id}, (err) => {
+    if (err) {
+      return res.status(400).json({error: err});
+    }
+    return res.sendStatus(204);
+  });
 });
 
-router.get('/', async (req, res) => {
-  const calEvents = await CalendarEvent.find();
-  res.json(calEvents);
-});
+// router.get('/', async (req, res) => {
+//   const calEvents = await CalendarEvent.find();
+//   res.json(calEvents);
+// });
 
 module.exports = router;

--- a/telos-backend/test/db-helper.js
+++ b/telos-backend/test/db-helper.js
@@ -11,6 +11,7 @@ module.exports.connectToDb = async () => {
   await mongoose.connect(uri, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
+    useFindAndModify: true,
   });
 };
 

--- a/telos-backend/test/integration/calendar_api.test.js
+++ b/telos-backend/test/integration/calendar_api.test.js
@@ -1,12 +1,16 @@
-const routes = require('../../src/routes');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const express = require('express');
 const mongoose = require('mongoose');
 const axios = require('axios');
+const routes = require('../../src/routes');
 const CalendarEvent = require('../../src/models/calendar_event');
 
-let mongod, app, server;
-let event1, event2, event3;
+let mongod;
+let app; 
+let server;
+let event1;
+let event2;
+let event3;
 
 beforeAll(async done => {
     mongod = new MongoMemoryServer();
@@ -120,8 +124,9 @@ it('can delete a thing', async () => {
 
 
 it('GET not defined', async () => {
+    let err;
     try{
-        const response = await axios.get('http://localhost:3000/api/calendar')
+        await axios.get('http://localhost:3000/api/calendar')
     } catch (error) {
         err = error;
     }

--- a/telos-backend/test/integration/calendar_api.test.js
+++ b/telos-backend/test/integration/calendar_api.test.js
@@ -6,129 +6,128 @@ const routes = require('../../src/routes');
 const CalendarEvent = require('../../src/models/calendar_event');
 
 let mongod;
-let app; 
+let app;
 let server;
 let event1;
 let event2;
 let event3;
 
-beforeAll(async done => {
-    mongod = new MongoMemoryServer();
+beforeAll(async (done) => {
+  mongod = new MongoMemoryServer();
 
-    const connectionString = await mongod.getUri();
-    await mongoose.connect(connectionString, { useNewUrlParser: true });
+  const connectionString = await mongod.getUri();
+  await mongoose.connect(connectionString, { useNewUrlParser: true });
 
-    app = express();
-    app.use(express.json());
-    app.use('/', routes);
-    server = app.listen(3000, () => done());
+  app = express();
+  app.use(express.json());
+  app.use('/', routes);
+  server = app.listen(3000, () => done());
 });
 
 beforeEach(async () => {
-    const coll = await mongoose.connection.db.createCollection('calendarevents');
+  const coll = await mongoose.connection.db.createCollection('calendarevents');
 
-    event1 = {
-        name: 'test1',
-        startTime: '2021-01-01T00:00:00',
-        endTime: '2021-01-01T05:00:00'
-    };
+  event1 = {
+    name: 'test1',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
 
-    event2 = {
-        name: 'test2',
-        startTime: '2021-01-01T00:00:00',
-        endTime: '2021-01-01T05:00:00'
-    };
+  event2 = {
+    name: 'test2',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
 
-    event3 = {
-        name: 'test3',
-        startTime: '2021-01-01T00:00:00',
-        endTime: '2021-01-01T05:00:00'
-    };
+  event3 = {
+    name: 'test3',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
 
-    await coll.insertMany([event1, event2, event3]);
+  await coll.insertMany([event1, event2, event3]);
 });
 
 afterEach(async () => {
-    await mongoose.connection.db.dropCollection('calendarevents');
+  await mongoose.connection.db.dropCollection('calendarevents');
 });
 
-afterAll(done => {
-    server.close(async () => {
-        await mongoose.disconnect();
-        await mongod.stop();
+afterAll((done) => {
+  server.close(async () => {
+    await mongoose.disconnect();
+    await mongod.stop();
 
-        done();
-    });
+    done();
+  });
 });
 
 it('Can post a calendar event', async () => {
-    const body = {
-        "name": "Test calendar",
-        "startTime": "2021-01-01T02:00:00",
-        "endTime": "2021-01-01T05:00:00"
-    };
-    const response = await axios.post('http://localhost:3000/api/calendar', {
-        name: 'Test calendar',
-        startTime: '2021-01-01T02:00:00',
-        endTime: '2021-01-01T05:00:00'
-    });
-    const returnEvent = response.data;
+  const body = {
+    name: 'Test calendar',
+    startTime: '2021-01-01T02:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
+  const response = await axios.post('http://localhost:3000/api/calendar', {
+    name: 'Test calendar',
+    startTime: '2021-01-01T02:00:00',
+    endTime: '2021-01-01T05:00:00',
+  });
+  const returnEvent = response.data;
 
-    expect(returnEvent._id).toBeDefined();
-    expect(new Date(returnEvent.startTime)).toStrictEqual(new Date(body.startTime));
+  expect(returnEvent._id).toBeDefined();
+  expect(new Date(returnEvent.startTime)).toStrictEqual(new Date(body.startTime));
 
-    // Response same as what is in database.
-    const calEvent = await CalendarEvent.findById(returnEvent._id);
-    expect(new Date(returnEvent.startTime)).toStrictEqual(calEvent.startTime);
-    expect(new Date(returnEvent.endTime)).toStrictEqual(calEvent.endTime);
-    expect(returnEvent.name).toBe(calEvent.name);
+  // Response same as what is in database.
+  const calEvent = await CalendarEvent.findById(returnEvent._id);
+  expect(new Date(returnEvent.startTime)).toStrictEqual(calEvent.startTime);
+  expect(new Date(returnEvent.endTime)).toStrictEqual(calEvent.endTime);
+  expect(returnEvent.name).toBe(calEvent.name);
 });
 
 it('Can put a calendar event to update it', async () => {
-    await axios.put(`http://localhost:3000/api/calendar/${event1._id}`, {
-        _id: event1._id,
-        name: 'Updated test1',
-        startTime: '2021-01-01T00:00:00',
-        endTime: '2021-01-01T06:00:00'
-    });
+  await axios.put(`http://localhost:3000/api/calendar/${event1._id}`, {
+    _id: event1._id,
+    name: 'Updated test1',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T06:00:00',
+  });
 
-    // Check 1 remains same, others change.
-    const calEvent = await CalendarEvent.findById(event1._id);
-    expect(calEvent.name).toBe('Updated test1');
-    
-    expect(calEvent.startTime).toStrictEqual(new Date('2021-01-01T00:00:00'));
-    expect(calEvent.endTime).toStrictEqual(new Date('2021-01-01T06:00:00'));
+  // Check 1 remains same, others change.
+  const calEvent = await CalendarEvent.findById(event1._id);
+  expect(calEvent.name).toBe('Updated test1');
+
+  expect(calEvent.startTime).toStrictEqual(new Date('2021-01-01T00:00:00'));
+  expect(calEvent.endTime).toStrictEqual(new Date('2021-01-01T06:00:00'));
 });
 
 it('can delete a thing', async () => {
-    const calEventsBeforeDelete = await CalendarEvent.find();
-    expect(calEventsBeforeDelete.length).toBe(3);
+  const calEventsBeforeDelete = await CalendarEvent.find();
+  expect(calEventsBeforeDelete.length).toBe(3);
 
-    await axios.delete(`http://localhost:3000/api/calendar/${event1._id}`);
-    const calEvents = await CalendarEvent.find();
+  await axios.delete(`http://localhost:3000/api/calendar/${event1._id}`);
+  const calEvents = await CalendarEvent.find();
 
-    expect(calEvents.length).toBe(2);
-    
-    // Check event2 is the same
-    expect(new Date(event2.startTime)).toStrictEqual(calEvents[0].startTime);
-    expect(new Date(event2.endTime)).toStrictEqual(calEvents[0].endTime);
-    expect(calEvents[0].name).toBe(event2.name);
-    expect(calEvents[0]._id).toStrictEqual(event2._id);
-    
-    // Check event3 is the same
-    expect(new Date(event3.startTime)).toStrictEqual(calEvents[1].startTime);
-    expect(new Date(event3.endTime)).toStrictEqual(calEvents[1].endTime);
-    expect(calEvents[1].name).toBe(event3.name);
-    expect(calEvents[1]._id).toStrictEqual(event3._id);
+  expect(calEvents.length).toBe(2);
+
+  // Check event2 is the same
+  expect(new Date(event2.startTime)).toStrictEqual(calEvents[0].startTime);
+  expect(new Date(event2.endTime)).toStrictEqual(calEvents[0].endTime);
+  expect(calEvents[0].name).toBe(event2.name);
+  expect(calEvents[0]._id).toStrictEqual(event2._id);
+
+  // Check event3 is the same
+  expect(new Date(event3.startTime)).toStrictEqual(calEvents[1].startTime);
+  expect(new Date(event3.endTime)).toStrictEqual(calEvents[1].endTime);
+  expect(calEvents[1].name).toBe(event3.name);
+  expect(calEvents[1]._id).toStrictEqual(event3._id);
 });
 
-
 it('GET not defined', async () => {
-    let err;
-    try{
-        await axios.get('http://localhost:3000/api/calendar')
-    } catch (error) {
-        err = error;
-    }
-    expect(err).toBeDefined();
+  let err;
+  try {
+    await axios.get('http://localhost:3000/api/calendar');
+  } catch (error) {
+    err = error;
+  }
+  expect(err).toBeDefined();
 });

--- a/telos-backend/test/integration/calendar_api.test.js
+++ b/telos-backend/test/integration/calendar_api.test.js
@@ -1,18 +1,90 @@
 const routes = require('../../src/routes');
-const server = 0;
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const mongoose = require('mongoose');
+const axios = require('axios');
 
+let mongod, app, server;
+
+/**
+ * Before all tests, create an in-memory MongoDB instance so we don't have to test on a real database,
+ * then establish a mongoose connection to it.
+ * 
+ * Also, start an express server running on port 3000, hosting the routes we wish to test.
+ */
 beforeAll(async done => {
+
+    mongod = new MongoMemoryServer();
+
+    const connectionString = await mongod.getUri();
+    await mongoose.connect(connectionString, { useNewUrlParser: true });
+
     app = express();
     app.use('/', routes);
-    server = app.listen(3001, () => done());
+    server = app.listen(3000, () => done());
 });
 
+/**
+ * Before each test, intialize the database with some data
+ */
+beforeEach(async () => {
+    const coll = await mongoose.connection.db.createCollection('calendar_events');
+});
+
+/**
+ * After each test, clear the database entirely
+ */
+afterEach(async () => {
+    await mongoose.connection.db.dropCollection('calendar_events');
+});
+
+/**
+ * After all tests, gracefully terminate the in-memory MongoDB instance and mongoose connection.
+ * 
+ * Also, stop the express server
+ */
 afterAll(done => {
     server.close(async () => {
+        await mongoose.disconnect();
+        await mongod.stop();
+
         done();
     });
 });
 
-it('will update', () => {
-    expect("wow").toBe("wow")
-})
+it('can post a thing', async () => {
+    const body = {
+        "name": "Test calendar",
+        "startTime": "2021-01-01T02:00:00",
+        "endTime": "2021-01-01T05:00:00"
+    };
+    axios.post('http://localhost:3000/api/calendar/', {
+        name: 'Test calendar',
+        startTime: '2021-01-01T02:00:00',
+        endTime: '2021-01-01T05:00:00'
+    });
+    //const returnEvent = response.data;
+
+    //expect(returnEvent._id).toBeDefined();
+});
+
+// it('can post a thing', async () => {
+//     await axios.put('http://localhost:3000/api/calendar/')
+// });
+
+// it('can delete a thing', async () => {
+//     await axios.delete('http://localhost:3000/api/calendar/')
+// });
+
+it ('works', () => {
+    expect("one").toBe("one")
+});
+
+it('get not defined', async () => {
+    try{
+        const response = await axios.get('http://localhost:3000/api/calendar')
+    } catch (error) {
+        err = error;
+    }
+    expect(err).toBeDefined();
+});

--- a/telos-backend/test/integration/calendar_api.test.js
+++ b/telos-backend/test/integration/calendar_api.test.js
@@ -19,7 +19,7 @@ beforeAll(async (done) => {
   await mongoose.connect(connectionString, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
-    useFindAndModify: true,
+    useFindAndModify: false,
   });
 
   app = express();
@@ -71,11 +71,7 @@ it('Can post a calendar event', async () => {
     startTime: '2021-01-01T02:00:00',
     endTime: '2021-01-01T05:00:00',
   };
-  const response = await axios.post('http://localhost:3000/api/calendar', {
-    name: 'Test calendar',
-    startTime: '2021-01-01T02:00:00',
-    endTime: '2021-01-01T05:00:00',
-  });
+  const response = await axios.post('http://localhost:3000/api/calendar', body);
   const returnEvent = response.data;
 
   expect(returnEvent._id).toBeDefined();

--- a/telos-backend/test/integration/calendar_api.test.js
+++ b/telos-backend/test/integration/calendar_api.test.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 const axios = require('axios');
 
 let mongod, app, server;
+let event1, event2, event3;
 
 /**
  * Before all tests, create an in-memory MongoDB instance so we don't have to test on a real database,
@@ -20,22 +21,40 @@ beforeAll(async done => {
     await mongoose.connect(connectionString, { useNewUrlParser: true });
 
     app = express();
+    app.use(express.json());
     app.use('/', routes);
     server = app.listen(3000, () => done());
 });
 
-/**
- * Before each test, intialize the database with some data
- */
 beforeEach(async () => {
-    const coll = await mongoose.connection.db.createCollection('calendar_events');
+    const coll = await mongoose.connection.db.createCollection('calendarevents');
+
+    event1 = {
+        name: 'test1',
+        startTime: '2021-01-01T00:00:00',
+        endTime: '2021-01-01T05:00:00'
+    };
+
+    event2 = {
+        name: 'test2',
+        startTime: '2021-01-01T00:00:00',
+        endTime: '2021-01-01T05:00:00'
+    };
+
+    event3 = {
+        name: 'test3',
+        startTime: '2021-01-01T00:00:00',
+        endTime: '2021-01-01T05:00:00'
+    };
+
+    await coll.insertMany([event1, event2, event3]);
 });
 
 /**
  * After each test, clear the database entirely
  */
 afterEach(async () => {
-    await mongoose.connection.db.dropCollection('calendar_events');
+    await mongoose.connection.db.dropCollection('calendarevents');
 });
 
 /**
@@ -58,14 +77,14 @@ it('can post a thing', async () => {
         "startTime": "2021-01-01T02:00:00",
         "endTime": "2021-01-01T05:00:00"
     };
-    axios.post('http://localhost:3000/api/calendar/', {
+    const response = await axios.post('http://localhost:3000/api/calendar', {
         name: 'Test calendar',
         startTime: '2021-01-01T02:00:00',
         endTime: '2021-01-01T05:00:00'
     });
-    //const returnEvent = response.data;
+    const returnEvent = response.data;
 
-    //expect(returnEvent._id).toBeDefined();
+    expect(returnEvent._id).toBeDefined();
 });
 
 // it('can post a thing', async () => {
@@ -81,10 +100,16 @@ it ('works', () => {
 });
 
 it('get not defined', async () => {
-    try{
-        const response = await axios.get('http://localhost:3000/api/calendar')
-    } catch (error) {
-        err = error;
-    }
-    expect(err).toBeDefined();
+    // try{
+    //     const response = await axios.get('http://localhost:3000/api/calendar')
+    // } catch (error) {
+    //     err = error;
+    // }
+    // expect(err).toBeDefined();
+    const response = await axios.get('http://localhost:3000/api/calendar');
+    const calevents = response.data;
+
+    expect(calevents.length).toBe(3);
+
+    expect(calevents[0].name).toBe('test1')
 });

--- a/telos-backend/test/integration/calendar_api.test.js
+++ b/telos-backend/test/integration/calendar_api.test.js
@@ -1,0 +1,18 @@
+const routes = require('../../src/routes');
+const server = 0;
+
+beforeAll(async done => {
+    app = express();
+    app.use('/', routes);
+    server = app.listen(3001, () => done());
+});
+
+afterAll(done => {
+    server.close(async () => {
+        done();
+    });
+});
+
+it('will update', () => {
+    expect("wow").toBe("wow")
+})

--- a/telos-backend/test/integration/calendar_api.test.js
+++ b/telos-backend/test/integration/calendar_api.test.js
@@ -16,7 +16,11 @@ beforeAll(async (done) => {
   mongod = new MongoMemoryServer();
 
   const connectionString = await mongod.getUri();
-  await mongoose.connect(connectionString, { useNewUrlParser: true });
+  await mongoose.connect(connectionString, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useFindAndModify: true,
+  });
 
   app = express();
   app.use(express.json());


### PR DESCRIPTION
Closes #35 

## Proposed Changes
Hooking up the model schema for calendar events to the `/api/calendar` endpoint with the specification that we defined previously.

This also defined the way to set up integration tests, such that we can test the app using jest, without affecting any local databases.
