### PR TITLE
Closes #141: Created Menu, updated routes for dashboard widgets

### DIFF
--- a/telos-frontend/src/App.js
+++ b/telos-frontend/src/App.js
@@ -18,50 +18,48 @@ import JournalText from './components/text/JournalText';
 function App() {
   return (
     <Router>
-      <Switch>
-        {/* links for easy testing of components */}
-        <Route path="/test/dashboard/calendar">
-          <CalendarDashboard />
-        </Route>
-        <Route path="/test/journal/calendar">
-          <CalendarJournal />
-        </Route>
-        <Route path="/test/dashboard/habittracker">
-          <DashboardHabitTracker />
-        </Route>
-        <Route path="/test/journal/habittracker">
-          <JournalHabitTracker />
-        </Route>
-        <Route path="/test/dashboard/todo">
-          <DashboardTodo />
-        </Route>
-        <Route path="/test/journal/todo">
-          <JournalTodo />
-        </Route>
-        <Route path="/test/topbar">
-          <TopBar />
-        </Route>
-        <Route path="/test/text">
-          <JournalText />
-        </Route>
-        <Route path="/widget-drawer">
-          <div className="app-container">
-            <WidgetDrawer>
-              <WidgetCalendar />
-              <WidgetTodo />
-              <WidgetHabitTracker />
-            </WidgetDrawer>
-          </div>
-        </Route>
+      <div className="App" data-testid="test">
+        <TopBar />
 
-        <Route path="*">
-          <div className="App" data-testid="test">
+        <Switch>
+          <Route path="/calendar">
+            <CalendarDashboard />
+          </Route>
+          <Route path="/habittracker">
+            <DashboardHabitTracker />
+          </Route>
+          <Route path="/todo">
+            <DashboardTodo />
+          </Route>
+          <Route path="/widget-drawer">
+            <div className="app-container">
+              <WidgetDrawer>
+                <WidgetCalendar />
+                <WidgetTodo />
+                <WidgetHabitTracker />
+              </WidgetDrawer>
+            </div>
+          </Route>
+          {/* links for easy testing of components */}
+          <Route path="/test/journal/calendar">
+            <CalendarJournal />
+          </Route>
+          <Route path="/test/journal/habittracker">
+            <JournalHabitTracker />
+          </Route>
+          <Route path="/test/journal/todo">
+            <JournalTodo />
+          </Route>
+          <Route path="/test/text">
+            <JournalText />
+          </Route>
+          <Route path="*">
             <div className="Journal-view">
               <Journal />
             </div>
-          </div>
-        </Route>
-      </Switch>
+          </Route>
+        </Switch>
+      </div>
     </Router>
   );
 }

--- a/telos-frontend/src/components/top-bar/TopBar.jsx
+++ b/telos-frontend/src/components/top-bar/TopBar.jsx
@@ -1,4 +1,7 @@
+import { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import AppBar from '@material-ui/core/AppBar';
+import Menu from '@material-ui/core/Menu';
 import { makeStyles } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -6,6 +9,12 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import SettingsIcon from '@material-ui/icons/Settings';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import MenuItem from '@material-ui/core/MenuItem';
+import ImportContactsIcon from '@material-ui/icons/ImportContacts';
+import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import CancelIcon from '@material-ui/icons/Cancel';
 
 //  Used to define styles of MUI components.
 const useStyles = makeStyles(() => ({
@@ -25,9 +34,22 @@ const useStyles = makeStyles(() => ({
 const TopBar = () => {
   const classes = useStyles();
 
-  //   Stub for menu button handler
-  function menuHandler() {
-    console.log('Menu button clicked');
+  const [anchorEl, setAnchorEl] = useState(null);
+  const history = useHistory();
+
+  function menuOpenHandler(event) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function menuCloseHandler() {
+    setAnchorEl(null);
+  }
+
+  function menuChoiceHandler(widget) {
+    if (widget) {
+      history.push(`/${widget}`);
+    }
+    menuCloseHandler();
   }
 
   //   Stub for user button handler
@@ -44,7 +66,7 @@ const TopBar = () => {
     <div>
       <AppBar position="static" className={classes.root}>
         <Toolbar>
-          <IconButton onClick={menuHandler} edge="start" color="inherit" aria-label="menu">
+          <IconButton onClick={menuOpenHandler} edge="start" color="inherit" aria-label="menu">
             <MenuIcon />
           </IconButton>
 
@@ -65,6 +87,35 @@ const TopBar = () => {
           </section>
         </Toolbar>
       </AppBar>
+
+      <Menu
+        id="simple-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={menuCloseHandler}
+      >
+        <MenuItem onClick={() => menuChoiceHandler('journal')}>
+          <ImportContactsIcon />
+          Journal
+        </MenuItem>
+        <MenuItem onClick={() => menuChoiceHandler('calendar')}>
+          <CalendarTodayIcon />
+          Calendar
+        </MenuItem>
+        <MenuItem onClick={() => menuChoiceHandler('todo')}>
+          <CheckBoxIcon />
+          Todo List
+        </MenuItem>
+        <MenuItem onClick={() => menuChoiceHandler('habittracker')}>
+          <MoreHorizIcon />
+          Habit Tracker
+        </MenuItem>
+        <MenuItem onClick={menuCloseHandler}>
+          <CancelIcon />
+          Cancel
+        </MenuItem>
+      </Menu>
     </div>
   );
 };

--- a/telos-frontend/src/components/top-bar/TopBar.jsx
+++ b/telos-frontend/src/components/top-bar/TopBar.jsx
@@ -3,18 +3,17 @@ import { useHistory } from 'react-router-dom';
 import AppBar from '@material-ui/core/AppBar';
 import Menu from '@material-ui/core/Menu';
 import { makeStyles } from '@material-ui/core/styles';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
-import IconButton from '@material-ui/core/IconButton';
-import MenuIcon from '@material-ui/icons/Menu';
-import SettingsIcon from '@material-ui/icons/Settings';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
-import MenuItem from '@material-ui/core/MenuItem';
-import ImportContactsIcon from '@material-ui/icons/ImportContacts';
-import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
-import CheckBoxIcon from '@material-ui/icons/CheckBox';
-import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
-import CancelIcon from '@material-ui/icons/Cancel';
+import { Toolbar, Typography, IconButton, MenuItem } from '@material-ui/core';
+import {
+  Menu as MenuIcon,
+  Settings as SettingsIcon,
+  AccountCircle as AccountCircleIcon,
+  ImportContacts as ImportContactsIcon,
+  CalendarToday as CalendarTodayIcon,
+  CheckBox as CheckBoxIcon,
+  MoreHoriz as MoreHorizIcon,
+  Cancel as CancelIcon,
+} from '@material-ui/icons';
 
 //  Used to define styles of MUI components.
 const useStyles = makeStyles(() => ({


### PR DESCRIPTION
Closes #141 

## Proposed Changes

- Added a dropdown menu to the top bar to choose between journal and each of the full screen widgets
- Changed the routing of App to always render TopBar
- Removed the test prefix from paths of full screen widgets routes in App


<img width="350" alt="image" src="https://user-images.githubusercontent.com/54158903/111859160-b12b1f80-89a3-11eb-8f4e-e01e8eaa9889.png">
