### PR TITLE
Text widget icon

### DIFF
--- a/telos-frontend/src/App.js
+++ b/telos-frontend/src/App.js
@@ -2,6 +2,7 @@ import './App.css';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Journal from './views/journal/Journal';
 import WidgetCalendar from './components/calendar/WidgetCalendar';
+import WidgetText from './components/text/WidgetText';
 import WidgetTodo from './components/todo/WidgetTodo';
 import WidgetDrawer from './components/widget-drawer/WidgetDrawer';
 import WidgetHabitTracker from './components/habit-tracker/WidgetHabitTracker';
@@ -37,6 +38,7 @@ function App() {
                 <WidgetCalendar />
                 <WidgetTodo />
                 <WidgetHabitTracker />
+                <WidgetText />
               </WidgetDrawer>
             </div>
           </Route>

--- a/telos-frontend/src/components/Widget.css
+++ b/telos-frontend/src/components/Widget.css
@@ -33,3 +33,12 @@
 .widget-icon:hover {
   background-color: rgba(122,0,244,0.08);
 }
+
+.big-text {
+  --bigTextSize: 36px;
+  font-size: var(--bigTextSize);
+  height: var(--bigTextSize);
+  line-height: var(--bigTextSize);
+  font-weight: 600;
+  color: var(--iconColour);
+}

--- a/telos-frontend/src/components/calendar/WidgetCalendar.css
+++ b/telos-frontend/src/components/calendar/WidgetCalendar.css
@@ -2,12 +2,3 @@
   font-size: 10px;
   font-weight: bold;
 }
-
-.big-number {
-  --bigTextSize: 36px;
-  font-size: var(--bigTextSize);
-  height: var(--bigTextSize);
-  line-height: var(--bigTextSize);
-  font-weight: 600;
-  color: var(--iconColour);
-}

--- a/telos-frontend/src/components/calendar/WidgetCalendar.jsx
+++ b/telos-frontend/src/components/calendar/WidgetCalendar.jsx
@@ -9,7 +9,7 @@ const WidgetTodo = () => {
   return (
     <div className="widget-icon vertical">
       <div className="small-month">{thisMonth}</div>
-      <div className="big-number">{thisDay}</div>
+      <div className="big-text">{thisDay}</div>
     </div>
   );
 };

--- a/telos-frontend/src/components/text/WidgetText.jsx
+++ b/telos-frontend/src/components/text/WidgetText.jsx
@@ -1,0 +1,9 @@
+import '../Widget.css';
+
+const WidgetText = () => (
+  <div className="widget-icon vertical">
+    <div className="big-text">T</div>
+  </div>
+);
+
+export default WidgetText;

--- a/telos-frontend/src/components/widget-drawer/WidgetDrawer.css
+++ b/telos-frontend/src/components/widget-drawer/WidgetDrawer.css
@@ -45,7 +45,7 @@
   right: 0;
 }
 
-.hidden {
+.technically-hidden {
   opacity: 0;
   visibility: hidden;
   width: 0;

--- a/telos-frontend/src/components/widget-drawer/WidgetDrawer.jsx
+++ b/telos-frontend/src/components/widget-drawer/WidgetDrawer.jsx
@@ -21,7 +21,7 @@ const WidgetDrawer = ({ children }) => {
       <div className={`closer ${isHidden ? 'flipped' : BLANK}`} onClick={handleOnClick}>
         <Arrow />
       </div>
-      <div className={`WidgetDrawer ${isHidden ? 'hidden' : BLANK}`}>{children}</div>
+      <div className={`WidgetDrawer ${isHidden ? 'technically-hidden' : BLANK}`}>{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
Closes #158

## Proposed Changes

- Added text widget icon to the widget drawer
- Has a style refactor so that both text widget icon and calendar widget icon can share styling

Screenshots:

![image](https://user-images.githubusercontent.com/68324342/111865972-06c8f180-89cf-11eb-970a-efc4eaed1f2a.png)

![image](https://user-images.githubusercontent.com/68324342/111865988-18aa9480-89cf-11eb-846c-7f60659e3ac7.png)
