### PR TITLE
Closes #176: Add all journal widgets to initial state of Journal view

### DIFF
--- a/telos-frontend/src/components/calendar/JournalCalendar.jsx
+++ b/telos-frontend/src/components/calendar/JournalCalendar.jsx
@@ -138,7 +138,7 @@ export default () => {
   }, [setData, currentViewName, currentDate]);
 
   return (
-    <Paper>
+    <Paper style={{ height: '100%' }}>
       <ThemeProvider theme={theme}>
         <Scheduler data={data} height="full">
           <ViewState

--- a/telos-frontend/src/dnd/utils.js
+++ b/telos-frontend/src/dnd/utils.js
@@ -9,11 +9,19 @@ export const renderWidget = (widgetType, props) => {
     case WidgetTypes.TODO_LIST:
       return <JournalTodo {...props} />;
     case WidgetTypes.CALENDAR:
-      return <JournalCalendar {...props} />;
+      return (
+        <div style={{ height: 400, maxWidth: 350 }}>
+          <JournalCalendar {...props} />
+        </div>
+      );
     case WidgetTypes.HABIT_TRACKER:
       return <JournalHabitTracker {...props} />;
     case WidgetTypes.TEXT:
-      return <JournalText {...props} />;
+      return (
+        <div style={{ height: 300, width: 250 }}>
+          <JournalText {...props} />
+        </div>
+      );
     default:
       return null;
   }

--- a/telos-frontend/src/views/journal/Journal.jsx
+++ b/telos-frontend/src/views/journal/Journal.jsx
@@ -40,8 +40,10 @@ const Journal = () => {
   }
 
   const [widgets, setWidgets] = useState([
-    { widgetType: 'todo', id: 0, top: 200, left: 200 },
-    { widgetType: 'habit_tracker', id: 1, top: 300, left: 300 },
+    { widgetType: 'todo', id: 0, top: 0, left: 0 },
+    { widgetType: 'habit_tracker', id: 1, top: 200, left: 200 },
+    { widgetType: 'text', id: 2, top: 100, left: 100 },
+    { widgetType: 'calendar', id: 3, top: 300, left: 300 },
   ]);
 
   const moveWidget = useCallback(


### PR DESCRIPTION
Closes #176 

## Proposed Changes

- Add Calendar and Text journal widgets to initial state
- Added container divs to Calendar and Text widgets to create a good size

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/54158903/111890566-6a92ff00-8a4f-11eb-8ac9-aa5be40d2334.png">
