### PR TITLE
Closes #173: Implement API endpoints for Journal view

### DIFF
--- a/telos-backend/src/models/text.js
+++ b/telos-backend/src/models/text.js
@@ -1,10 +1,7 @@
 const mongoose = require('mongoose');
 
 const textSchema = new mongoose.Schema({
-  text: {
-    type: String,
-    required: true,
-  },
+  text: String,
   // foreign-key to widget model
   widgetId: {
     type: mongoose.SchemaTypes.ObjectId,

--- a/telos-backend/src/routes/api/journal.js
+++ b/telos-backend/src/routes/api/journal.js
@@ -1,14 +1,119 @@
 const express = require('express');
+const CalendarEvent = require('../../models/calendar_event');
+const Habit = require('../../models/habit');
+const Text = require('../../models/text');
+const TodoTask = require('../../models/todo_task');
+const Widget = require('../../models/widget');
 
 const router = express.Router();
+
+// Helper methods ---------------------------------
+// Return a string representation of current day. 
+// See daysOfWeekenum in src/models/habit.js
+function getStringDayOfWeek(dayNum) {
+  let dayString;
+  switch (dayNum) {
+    case 0:
+      dayString = 'sun';
+      break;
+    case 1:
+      dayString = 'mon';
+      break;
+    case 2:
+      dayString = 'tue';
+      break;
+    case 3:
+      dayString = 'wed';
+      break;
+    case 4:
+      dayString = 'thu';
+      break;
+    case 5:
+      dayString = 'fri';
+      break;
+    case 6:
+      dayString = 'sat';
+      break;
+    default:
+      dayString = 'err';
+  }
+  return dayString;
+}
+
+async function getTodosForDay(date){
+  // Todos should return either what is made today, or all overdue tasks.
+  const todos = await TodoTask.find({
+    $or:[
+      { createdDate: { $gte: date + 'T00:00:00', $lte: date + 'T23:59:59' } }, 
+      { dueDate: {$gte: date + 'T00:00:00'} }
+    ] 
+  });
+  return todos;
+}
+
+// Param: date, of type date, parsed from url path param.
+async function getHabitsForDay(date){
+  // Create habit objects to return. These are not stored directly (since technically could be unlimited)
+  // Must find all habits that are between the requested day, but before end date, then check if they fall
+  // on the current day.
+  const habits = await Habit.find({ startDate: {$gte: date + 'T00:00:00'}, endDate: {$lte: date + 'T23:59:59'}});
+  // Habit objects returned in array as following:
+  // {
+  //    name: String
+  //    done: Boolean
+  // }
+  // Note: The Date.getDay() method returns an integer for day of week: 0 for sunday, 1 for monday etc.
+  const day = new Date(date).getDay();
+  const dayOfWeek = getStringDayOfWeek(day)
+  const habitDataToSend = []
+  for (const h in habits){
+    // Check if habit falls on day of week.
+    if (h.daysOfWeek.includes(dayOfWeek)){ 
+      habitDataToSend.push({
+        name: h.name,
+        completed: h.completedDates.includes(new Date(date))
+      })
+    }
+  }
+  return habitDataToSend;
+}
+
+async function getCalendarDataForDay(date) {
+  const calendarevents = await CalendarEvent.find({ startTime: {
+    $gte: date + 'T00:00:00', 
+    $lte: date + 'T23:59:59'
+  }});
+  return calendarevents;
+}
+// ------------------------------------
+// Endpoints defined from this point on 
 
 // get widgets which appear in the journal for a single date.
 // params:
 // 'date': journal date to get widgets for
-router.get('/:date', (req, res) => {
+router.get('/:date', async (req, res) => {
+  const { date } = req.params;
+  //2021-01-01
+  // Need to get all the data from widgets on that date.
+  // Then go through each of components, if exist, and get the data.
+  const widgets = await Widget.find({ date: date });
+
+  // Must find all text widgets based on the widget Ids retrieved.
+  const widgetIds = []
+  for (const w in widgets) {
+    widgetIds.push(w.widgetId);
+  }
+  const texts = await Text.find({ _id: { $in: widgetIds }});
+  const calendarData = await getCalendarDataForDay(date);
+  const habitData = await getHabitsForDay(date);
+  const todoData = await getTodosForDay(date);
+
   res.json({
-    endpoint: '/journal',
-    request: `GET date: ${req.params.date}`,
+    widgetData: widgets,
+    calendarData: calendarData,
+    habitData: habitData,
+    textData: texts,
+    todoData: todoData,
   });
 });
 
@@ -17,10 +122,40 @@ router.get('/:date', (req, res) => {
 // 'date': date to insert widget into
 // 'position': position of widget in journal for the specified date
 // 'widget': type of widget i.e. 'calendar', etc.
-router.post('/', (req, res) => {
-  res.json({
-    endpoint: '/journal',
-    request: `POST date: ${req.body.date}, position: ${req.body.position}, widget: ${req.body.widget}`,
+router.post('/', async (req, res) => {
+  const date = req.body.date
+  const newWidget = new Widget({
+    date: date,
+    position: {
+      row: req.body.position.row,
+      col: req.body.position.col
+    },
+    type: req.body.type,
+  });
+  newWidget.save(async (err) => {
+    if (err) {
+      return res.status(400).json({ error: err });
+    }
+    let data;
+    const type = req.body.type;
+    switch(type){
+      case 'calendar':
+        data = await getCalendarDataForDay(date);
+        break
+      case 'todo':
+        data = await getTodosForDay(date);
+        break
+      case 'habit_tracker':
+        data = await getHabitsForDay(date);
+        break
+      case 'text':
+        data = await Text.findById(newWidget._id);
+        break
+    }
+    return res.status(201).json({
+      widget: newWidget,
+      data: data,
+    });
   });
 });
 
@@ -29,17 +164,24 @@ router.post('/', (req, res) => {
 // 'date': date to insert widget into
 // 'position': position of widget in journal for the specified date
 router.put('/:id', (req, res) => {
-  res.json({
-    endpoint: '/journal',
-    request: `PUT id: ${req.params.id}, date: ${req.body.date}, position: ${req.body.position}`,
+  const query = { _id: req.params.id };
+
+  Widget.findOneAndUpdate(query, req.body, (err) => {
+    if (err) {
+      return res.status(400).json({ error: err });
+    }
+    return res.sendStatus(204);
   });
 });
 
 // delete widget in journal page (but not any associated data)
 router.delete('/:id', (req, res) => {
-  res.json({
-    endpoint: '/journal',
-    request: `DELETE id: ${req.params.id}`,
+  const { id } = req.params;
+  Widget.deleteOne({ _id: id }, (err) => {
+    if (err) {
+      return res.status(400).json({ error: err });
+    }
+    return res.sendStatus(204);
   });
 });
 

--- a/telos-backend/src/routes/api/journal.js
+++ b/telos-backend/src/routes/api/journal.js
@@ -120,7 +120,6 @@ router.get('/:date', async (req, res) => {
   const textWidgetIds = []
   for (var i = 0; i < widgets.length; i++) {
     if (widgets[i].type === 'text'){
-      console.log(widgets[i]._id)
       textWidgetIds.push(widgets[i]._id);
     }
   }
@@ -222,12 +221,3 @@ router.delete('/:id', (req, res) => {
 });
 
 module.exports = router;
-
-// (err) => {
-//   if (err) {
-//     return res.status(400).json({ error: err });
-//   }
-//   return res.status(201).json({
-//     widget: newWidget,
-//     data: newText,
-//   }

--- a/telos-backend/src/routes/api/journal.js
+++ b/telos-backend/src/routes/api/journal.js
@@ -1,5 +1,5 @@
+/* eslint-disable prefer-template, no-plusplus, object-shorthand, no-case-declarations, prefer-destructuring, default-case  */
 const express = require('express');
-const mongoose = require('mongoose')
 const CalendarEvent = require('../../models/calendar_event');
 const Habit = require('../../models/habit');
 const Text = require('../../models/text');
@@ -9,7 +9,7 @@ const Widget = require('../../models/widget');
 const router = express.Router();
 
 // Helper methods ---------------------------------
-// Return a string representation of current day. 
+// Return a string representation of current day.
 // See daysOfWeekenum in src/models/habit.js
 function getStringDayOfWeek(dayNum) {
   let dayString;
@@ -41,32 +41,27 @@ function getStringDayOfWeek(dayNum) {
   return dayString;
 }
 
-async function getTodosForDay(date){
+async function getTodosForDay(date) {
   // Todos should return either what is made today, or all overdue tasks.
-  //console.log("In todos")
-  //console.log(date)
   const todos = await TodoTask.find({
-    $or:[
+    $or: [
       { createdDate: { $gte: date + 'T00:00:00', $lte: date + 'T23:59:59' } },
-      { dueDate: {$gte: date + 'T00:00:00', $lte: date + 'T23:59:59' } },
-      { dueDate: {$lt: date + 'T00:00:00'}, completed: false}
-    ] 
+      { dueDate: { $gte: date + 'T00:00:00', $lte: date + 'T23:59:59' } },
+      { dueDate: { $lt: date + 'T00:00:00' }, completed: false },
+    ],
   });
   return todos;
 }
 
 // Param: date, of type date, parsed from url path param. Given as yyyy-mm-dd
-async function getHabitsForDay(date){
+async function getHabitsForDay(date) {
   // Create habit objects to return. These are not stored directly (since technically could be unlimited)
   // Must find all habits that are between the requested day, but before end date, then check if they fall
   // on the current day.
-  //console.log(date)
   const habits = await Habit.find({
-    startDate: {$lte: date + 'T23:59:59'}, 
-    endDate: {$gte: date + 'T00:00:00'},
-  }); //endDate: {$lte: date + 'T23:59:59'} 
-  //{startDate: {$lte: new Date('2000-01-01T00:00:00Z')}}
-  //console.log(habits);
+    startDate: { $lte: date + 'T23:59:59' },
+    endDate: { $gte: date + 'T00:00:00' },
+  });
   // Habit objects returned in array as following:
   // {
   //    name: String
@@ -76,55 +71,55 @@ async function getHabitsForDay(date){
   const day = new Date(date).getDay();
   const dayOfWeek = getStringDayOfWeek(day);
   const habitDataToSend = [];
-  for (var i = 0; i < habits.length; i++) {
+  for (let i = 0; i < habits.length; i++) {
     // Check if habit falls on day of week.
-    //console.log(new Date(date))
     const compDates = habits[i].completedDates;
 
-    // We must cast to string because the compDates array has Strings in it! 
+    // We must cast to string because the compDates array has Strings in it!
     // (try console.log this value without it)
-    const completedValue = compDates.includes(String(new Date(date)))
-    if (habits[i].daysOfWeek.includes(dayOfWeek)){ 
+    const completedValue = compDates.includes(String(new Date(date)));
+    if (habits[i].daysOfWeek.includes(dayOfWeek)) {
       habitDataToSend.push({
         _id: habits[i]._id,
         date: date,
         name: habits[i].name,
-        completed: completedValue
-      })
+        completed: completedValue,
+      });
     }
   }
   return habitDataToSend;
 }
 
 async function getCalendarDataForDay(date) {
-  const calendarevents = await CalendarEvent.find({ startTime: {
-    $gte: date + 'T00:00:00', 
-    $lte: date + 'T23:59:59'
-  }});
+  const calendarevents = await CalendarEvent.find({
+    startTime: {
+      $gte: date + 'T00:00:00',
+      $lte: date + 'T23:59:59',
+    },
+  });
   return calendarevents;
 }
 // ------------------------------------
-// Endpoints defined from this point on 
+// Endpoints defined from this point on
 
 // get widgets which appear in the journal for a single date.
 // params:
 // 'date': journal date to get widgets for
 router.get('/:date', async (req, res) => {
   const { date } = req.params;
-  //2021-01-01
   // Need to get all the data from widgets on that date.
   // Then go through each of components, if exist, and get the data.
   const widgets = await Widget.find({ date: date });
 
   // Must find all text widgets based on the widget Ids retrieved.
-  const textWidgetIds = []
-  for (var i = 0; i < widgets.length; i++) {
-    if (widgets[i].type === 'text'){
+  const textWidgetIds = [];
+  for (let i = 0; i < widgets.length; i++) {
+    if (widgets[i].type === 'text') {
       textWidgetIds.push(widgets[i]._id);
     }
   }
 
-  const texts = await Text.find({ widgetId: { $in: textWidgetIds }});
+  const texts = await Text.find({ widgetId: { $in: textWidgetIds } });
   const calendarData = await getCalendarDataForDay(date);
   const habitData = await getHabitsForDay(date);
   const todoData = await getTodosForDay(date);
@@ -144,12 +139,12 @@ router.get('/:date', async (req, res) => {
 // 'position': position of widget in journal for the specified date
 // 'widget': type of widget i.e. 'calendar', etc.
 router.post('/', async (req, res) => {
-  const date = req.body.date
+  const date = req.body.date;
   const newWidget = new Widget({
     date: date,
     position: {
       row: req.body.position.row,
-      col: req.body.position.col
+      col: req.body.position.col,
     },
     type: req.body.type,
   });
@@ -160,28 +155,28 @@ router.post('/', async (req, res) => {
     let error;
     let data;
     const type = req.body.type;
-    switch(type){
+    switch (type) {
       case 'calendar':
         data = await getCalendarDataForDay(date);
-        break
+        break;
       case 'todo':
         data = await getTodosForDay(date);
-        break
+        break;
       case 'habit_tracker':
         data = await getHabitsForDay(date);
-        break
+        break;
       case 'text':
         const newText = new Text({
           text: '',
           widgetId: newWidget._id,
         });
-        await newText.save((err) => {
-          if (err) {
-            error = err;
+        await newText.save((err2) => {
+          if (err2) {
+            error = err2;
           }
         });
         data = [newText];
-        break
+        break;
     }
     if (error) {
       return res.status(400).json({ error: error });
@@ -192,7 +187,7 @@ router.post('/', async (req, res) => {
     });
   });
 });
-  
+
 // update widget in journal (e.g. change date, change position)
 // request body:
 // 'date': date to insert widget into

--- a/telos-backend/src/routes/api/journal.js
+++ b/telos-backend/src/routes/api/journal.js
@@ -124,7 +124,7 @@ router.get('/:date', async (req, res) => {
   const habitData = await getHabitsForDay(date);
   const todoData = await getTodosForDay(date);
 
-  res.json({
+  res.status(200).json({
     widgetData: widgets,
     calendarData: calendarData,
     habitData: habitData,

--- a/telos-backend/test/integration/journal_api.test.js
+++ b/telos-backend/test/integration/journal_api.test.js
@@ -1,0 +1,94 @@
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const mongoose = require('mongoose');
+const axios = require('axios');
+const routes = require('../../src/routes');
+const CalendarEvent = require('../../src/models/calendar_event');
+
+let mongod;
+let app;
+let server;
+let event1;
+let event2;
+let event3;
+let widget1, widget2, widget3;
+
+beforeAll(async (done) => {
+  mongod = new MongoMemoryServer();
+
+  const connectionString = await mongod.getUri();
+  await mongoose.connect(connectionString, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useFindAndModify: false,
+  });
+
+  app = express();
+  app.use(express.json());
+  app.use('/', routes);
+  server = app.listen(0, () => {
+    port = server.address().port;
+    done();
+  });
+});
+
+beforeEach(async () => {
+  const widgetColl = await mongoose.connection.db.createCollection('widgets');
+  widget1 = {
+    name: 'test1',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
+  widget2 = {
+    name: 'test2',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
+  await widgetColl.insertMany([widget1, widget2]);
+
+  const calendarColl = await mongoose.connection.db.createCollection('calendarevents');
+  event1 = {
+    name: 'test1',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
+  event2 = {
+    name: 'test2',
+    startTime: '2021-01-01T00:00:00',
+    endTime: '2021-01-01T05:00:00',
+  };
+  await calendarColl.insertMany([event1, event2]);
+
+
+});
+
+afterEach(async () => {
+  //await mongoose.connection.db.dropCollection('calendarevents');
+  //await mongoose.connection.db.dropCollection('widgets');
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll((done) => {
+  server.close(async () => {
+    await mongoose.disconnect();
+    await mongod.stop();
+
+    done();
+  });
+});
+
+it('Can post to create a new widget and receive widget data in response', async () => {
+
+});
+
+it('Can PUT to update position of widget', async () => {
+
+});
+
+it('Can delete a widget', async () => {
+
+});
+
+it('Can GET all widgets for a day, with all the widget data for the day', async () => {
+
+});

--- a/telos-backend/test/integration/journal_api.test.js
+++ b/telos-backend/test/integration/journal_api.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable one-var, no-undef,  */
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const express = require('express');
 const mongoose = require('mongoose');
@@ -10,11 +11,11 @@ const Habit = require('../../src/models/habit');
 const Todo = require('../../src/models/todo_task');
 
 let mongod, app, server;
-let newEvent1, newEvent2;
+let newEvent1;
 let event1, event2;
 let newWidget1, newWidget2, newWidget3;
 let habit1, habit2;
-let newText1, text2;
+let newText1;
 let todo1, todo2;
 let port;
 
@@ -38,42 +39,42 @@ beforeAll(async (done) => {
 });
 
 beforeEach(async () => {
-  //const widgetColl = await mongoose.connection.db.createCollection('widgets');
+  // const widgetColl = await mongoose.connection.db.createCollection('widgets');
   widget1 = {
     date: '2021-01-01',
     position: {
-        row: 2,
-        col: 2,
+      row: 2,
+      col: 2,
     },
-    type: 'habit_tracker'
+    type: 'habit_tracker',
   };
   widget2 = {
     date: '2021-01-01',
     position: {
-        row: 2,
-        col: 3,
+      row: 2,
+      col: 3,
     },
-    type: 'todo'
+    type: 'todo',
   };
   widget3 = {
     date: '2021-02-03',
     position: {
-        row: 2,
-        col: 3,
+      row: 2,
+      col: 3,
     },
-    type: 'text'
+    type: 'text',
   };
   // Note: Doing this way because of how times are saved.
   // When .save(), converts auto to UTC. This is the way we intend it to work
-  newWidget1 = new Widget(widget1)
-  await newWidget1.save()
-  newWidget2 = new Widget(widget2)
-  await newWidget2.save()
-  newWidget3 = new Widget(widget3)
-  await newWidget3.save()
+  newWidget1 = new Widget(widget1);
+  await newWidget1.save();
+  newWidget2 = new Widget(widget2);
+  await newWidget2.save();
+  newWidget3 = new Widget(widget3);
+  await newWidget3.save();
   // await widgetColl.insertMany([widget1, widget2, widget3]);
 
-  //const calendarColl = await mongoose.connection.db.createCollection('calendarevents');
+  // const calendarColl = await mongoose.connection.db.createCollection('calendarevents');
   event1 = {
     name: 'test1',
     startTime: '2021-01-01T00:00:00',
@@ -84,14 +85,14 @@ beforeEach(async () => {
     startTime: '2020-12-31T00:00:00',
     endTime: '2020-12-31T05:00:00',
   };
-  
-  newEvent1 = new CalendarEvent(event1)
-  await newEvent1.save()
-  const newEvent2 = new CalendarEvent(event2)
-  await newEvent2.save()
-  //await calendarColl.insertMany([event1, event2]);
 
-  //const habitColl = await mongoose.connection.db.createCollection('habits');
+  newEvent1 = new CalendarEvent(event1);
+  await newEvent1.save();
+  const newEvent2 = new CalendarEvent(event2);
+  await newEvent2.save();
+  // await calendarColl.insertMany([event1, event2]);
+
+  // const habitColl = await mongoose.connection.db.createCollection('habits');
   habit1 = {
     name: 'test1',
     startDate: '2021-01-01', // This is a Friday
@@ -105,56 +106,55 @@ beforeEach(async () => {
     daysOfWeek: ['mon', 'tue', 'thu'],
   };
 
-  const newHabit1 = new Habit(habit1)
-  await newHabit1.save()
-  const newHabit2 = new Habit(habit2)
-  await newHabit2.save()
-  //await habitColl.insertMany([habit1, habit2]);
+  const newHabit1 = new Habit(habit1);
+  await newHabit1.save();
+  const newHabit2 = new Habit(habit2);
+  await newHabit2.save();
+  // await habitColl.insertMany([habit1, habit2]);
 
-  //const textWidget = await Widget.find({type: 'text'})
-  //const textColl = await mongoose.connection.db.createCollection('texts');
+  // const textColl = await mongoose.connection.db.createCollection('texts');
   text1 = {
     text: 'text1',
-    widgetId: newWidget3._id // maybe just widget3._id
+    widgetId: newWidget3._id,
   };
-  newText1 = new Text(text1)
-  await newText1.save()
-  //await textColl.insertMany([text1]);
+  newText1 = new Text(text1);
+  await newText1.save();
+  // await textColl.insertMany([text1]);
 
-  //const todoColl = await mongoose.connection.db.createCollection('todo_tasks');
+  // const todoColl = await mongoose.connection.db.createCollection('todo_tasks');
   todo1 = {
     name: 'test1',
     createdDate: '2021-01-01',
     dueDate: '2021-01-01',
-    completed: true
+    completed: true,
   };
   todo2 = {
     name: 'test2',
     createdDate: '2020-01-01',
     dueDate: '2021-01-01',
-    completed: false
+    completed: false,
   };
   todo3 = {
     name: 'test3',
     createdDate: '2021-01-01',
     dueDate: '2023-01-01',
-    completed: true
+    completed: true,
   };
   todo4 = {
     name: 'test3',
     createdDate: '2020-01-01',
     dueDate: '2023-01-01',
-    completed: false
+    completed: false,
   };
-  const newTodo1 = new Todo(todo1)
-  await newTodo1.save()
-  const newTodo2 = new Todo(todo2)
-  await newTodo2.save()
-  const newTodo3 = new Todo(todo3)
-  await newTodo3.save()
-  const newTodo4 = new Todo(todo4)
-  await newTodo4.save()
-  //await todoColl.insertMany([todo1, todo2]);
+  const newTodo1 = new Todo(todo1);
+  await newTodo1.save();
+  const newTodo2 = new Todo(todo2);
+  await newTodo2.save();
+  const newTodo3 = new Todo(todo3);
+  await newTodo3.save();
+  const newTodo4 = new Todo(todo4);
+  await newTodo4.save();
+  // await todoColl.insertMany([todo1, todo2]);
 });
 
 afterEach(async () => {
@@ -173,60 +173,58 @@ afterAll((done) => {
 // Post for text
 // delete for text
 it('Can post to create a new widget and receive widget data in response', async () => {
-    const body = {
-        date: '2021-01-01',
-        position: {
-            row: 1,
-            col: 1,
-        },
-        type: 'calendar'
-      };
-    const response = await axios.post(`http://localhost:${port}/api/journal`, body);
-    const returnData = response.data;
-    // Expect a response of the form: {
-    // widget: {(same as above, but with _id field)}
-    // data: {same as making data above eg. for calendar, but with an _id field}
-    //}
-    // Expect to get the first calendar event only
-    expect(returnData.data.length).toBe(1);
-    expect(returnData.data[0].name).toBe(newEvent1.name);
-    
-    expect(returnData.widget._id).toBeDefined();
-    expect(returnData.widget.type).toBe('calendar');
-    expect(returnData.widget.position.row).toBe(body.position.row)
+  const body = {
+    date: '2021-01-01',
+    position: {
+      row: 1,
+      col: 1,
+    },
+    type: 'calendar',
+  };
+  const response = await axios.post(`http://localhost:${port}/api/journal`, body);
+  const returnData = response.data;
+  // Expect a response of the form: {
+  // widget: {(same as above, but with _id field)}
+  // data: {same as making data above eg. for calendar, but with an _id field}
+  // }
+  // Expect to get the first calendar event only
+  expect(returnData.data.length).toBe(1);
+  expect(returnData.data[0].name).toBe(newEvent1.name);
+
+  expect(returnData.widget._id).toBeDefined();
+  expect(returnData.widget.type).toBe('calendar');
+  expect(returnData.widget.position.row).toBe(body.position.row);
 });
 
-
 it('Can post to create a new text widget and receive widget data in response', async () => {
-    // This test is made as creating a text widget must also create a Text object in db with 
-    // empty string.
-    const body = {
-        date: '2021-02-03',
-        position: {
-            row: 1,
-            col: 1,
-        },
-        type: 'text'
-      };
-    const response = await axios.post(`http://localhost:${port}/api/journal`, body);
-    const returnData = response.data;
-    expect(returnData.data.length).toBe(1);
-    expect(returnData.data[0].text).toBe(''); // Expect the empty string for new Text
-    
-    expect(returnData.widget._id).toBeDefined();
-    expect(returnData.widget.type).toBe('text');
-    expect(returnData.widget.position.row).toBe(body.position.row)
-    
+  // This test is made as creating a text widget must also create a Text object in db with
+  // empty string.
+  const body = {
+    date: '2021-02-03',
+    position: {
+      row: 1,
+      col: 1,
+    },
+    type: 'text',
+  };
+  const response = await axios.post(`http://localhost:${port}/api/journal`, body);
+  const returnData = response.data;
+  expect(returnData.data.length).toBe(1);
+  expect(returnData.data[0].text).toBe(''); // Expect the empty string for new Text
+
+  expect(returnData.widget._id).toBeDefined();
+  expect(returnData.widget.type).toBe('text');
+  expect(returnData.widget.position.row).toBe(body.position.row);
 });
 
 it('Can PUT to update position of widget', async () => {
-    await axios.put(`http://localhost:${port}/api/journal/${newWidget1._id}`, {
-        position: {
-            row: 3, //Change row and col
-            col: 4,
-        },
-    });
-    
+  await axios.put(`http://localhost:${port}/api/journal/${newWidget1._id}`, {
+    position: {
+      row: 3, // Change row and col
+      col: 4,
+    },
+  });
+
   const widgetData = await Widget.findById(newWidget1._id);
   expect(widgetData.position.row).toBe(3);
   expect(widgetData.position.col).toBe(4);
@@ -237,35 +235,34 @@ it('Can PUT to update position of widget', async () => {
 });
 
 it('Can delete a widget', async () => {
-    await axios.delete(`http://localhost:${port}/api/journal/${newWidget2._id}`);
-    const widgets = await Widget.find();
-    expect(widgets.length).toBe(2);
+  await axios.delete(`http://localhost:${port}/api/journal/${newWidget2._id}`);
+  const widgets = await Widget.find();
+  expect(widgets.length).toBe(2);
 
-    expect(widgets[0].name).toBe(newWidget1.name);
-    expect(widgets[1].name).toBe(newWidget3.name);
+  expect(widgets[0].name).toBe(newWidget1.name);
+  expect(widgets[1].name).toBe(newWidget3.name);
 });
 
 it('Can GET all widgets for a day, with all the widget data for the day', async () => {
   const response = await axios.get(`http://localhost:${port}/api/journal/2021-01-01`);
   const returnData = response.data;
   // Expect a response as follows:
-//   {
-//       widgetData: [array of widgets like above, with _id fields]
-//       calendarData: [array of all calendar data on day, regardless if widget present]
-//       habitData: [array of habit data on day, regardless if widget present]
-//       textData: []
-//       todoData: []
-//   }
-// Idea is that all info is given and used as necessary.
+  //   {
+  //       widgetData: [array of widgets like above, with _id fields]
+  //       calendarData: [array of all calendar data on day, regardless if widget present]
+  //       habitData: [array of habit data on day, regardless if widget present]
+  //       textData: []
+  //       todoData: []
+  //   }
+  // Idea is that all info is given and used as necessary.
   expect(returnData.widgetData.length).toBe(2);
-  expect(returnData.widgetData[0].position.row).toBe(2); //position defined
+  expect(returnData.widgetData[0].position.row).toBe(2); // Position defined
   expect(returnData.widgetData[0].type).toBe('habit_tracker');
 
   expect(returnData.calendarData.length).toBe(1);
   expect(returnData.textData.length).toBe(0);
   expect(returnData.habitData.length).toBe(1);
   expect(returnData.todoData.length).toBe(3); // Either overdue or present for all of them
-  
 });
 
 it('Can GET a text widget', async () => {
@@ -277,12 +274,11 @@ it('Can GET a text widget', async () => {
   expect(returnData.textData[0].widgetId).toBe(newWidget3.id);
   expect(returnData.habitData.length).toBe(0);
   expect(returnData.todoData.length).toBe(1);
-  
 });
 
 it('Can GET a habit widget using the no enddate/unlimted option', async () => {
-    const response = await axios.get(`http://localhost:${port}/api/journal/2022-02-07`);
-    const returnData = response.data;
-    expect(returnData.habitData.length).toBe(1);
-    expect(returnData.habitData[0].date).toBe('2022-02-07');
+  const response = await axios.get(`http://localhost:${port}/api/journal/2022-02-07`);
+  const returnData = response.data;
+  expect(returnData.habitData.length).toBe(1);
+  expect(returnData.habitData[0].date).toBe('2022-02-07');
 });

--- a/telos-backend/test/integration/journal_api.test.js
+++ b/telos-backend/test/integration/journal_api.test.js
@@ -4,14 +4,21 @@ const mongoose = require('mongoose');
 const axios = require('axios');
 const routes = require('../../src/routes');
 const CalendarEvent = require('../../src/models/calendar_event');
+const Text = require('../../src/models/text');
+const Widget = require('../../src/models/widget');
+const Habit = require('../../src/models/habit');
+const Todo = require('../../src/models/todo_task');
 
 let mongod;
 let app;
 let server;
 let event1;
 let event2;
-let event3;
 let widget1, widget2, widget3;
+let habit1, habit2;
+let text1, text2;
+let todo1, todo2;
+let port;
 
 beforeAll(async (done) => {
   mongod = new MongoMemoryServer();
@@ -33,20 +40,42 @@ beforeAll(async (done) => {
 });
 
 beforeEach(async () => {
-  const widgetColl = await mongoose.connection.db.createCollection('widgets');
+  //const widgetColl = await mongoose.connection.db.createCollection('widgets');
   widget1 = {
-    name: 'test1',
-    startTime: '2021-01-01T00:00:00',
-    endTime: '2021-01-01T05:00:00',
+    date: '2021-01-01',
+    position: {
+        row: 2,
+        col: 2,
+    },
+    type: 'habit_tracker'
   };
   widget2 = {
-    name: 'test2',
-    startTime: '2021-01-01T00:00:00',
-    endTime: '2021-01-01T05:00:00',
+    date: '2021-01-01',
+    position: {
+        row: 2,
+        col: 3,
+    },
+    type: 'todo'
   };
-  await widgetColl.insertMany([widget1, widget2]);
+  widget3 = {
+    date: '2021-02-03',
+    position: {
+        row: 2,
+        col: 3,
+    },
+    type: 'text'
+  };
+  // Note: Doing this way because of how times are saved.
+  // When .save(), converts auto to UTC. This is the way we intend it to worl
+  const newWidget1 = new Widget(widget1)
+  await newWidget1.save()
+  const newWidget2 = new Widget(widget2)
+  await newWidget2.save()
+  const newWidget3 = new Widget(widget3)
+  await newWidget3.save()
+ // await widgetColl.insertMany([widget1, widget2, widget3]);
 
-  const calendarColl = await mongoose.connection.db.createCollection('calendarevents');
+  //const calendarColl = await mongoose.connection.db.createCollection('calendarevents');
   event1 = {
     name: 'test1',
     startTime: '2021-01-01T00:00:00',
@@ -54,12 +83,80 @@ beforeEach(async () => {
   };
   event2 = {
     name: 'test2',
-    startTime: '2021-01-01T00:00:00',
-    endTime: '2021-01-01T05:00:00',
+    startTime: '2020-12-31T00:00:00',
+    endTime: '2020-12-31T05:00:00',
   };
-  await calendarColl.insertMany([event1, event2]);
+  
+  const newEvent1 = new CalendarEvent(event1)
+  await newEvent1.save()
+  const newEvent2 = new CalendarEvent(event2)
+  await newEvent2.save()
+  //await calendarColl.insertMany([event1, event2]);
 
+  //const habitColl = await mongoose.connection.db.createCollection('habits');
+  habit1 = {
+    name: 'test1',
+    startDate: '2021-01-01', // This is a Friday
+    endDate: '2021-01-08',
+    daysOfWeek: ['mon', 'tue', 'fri'],
+    completedDates: ['2021-01-01'],
+  };
+  habit2 = {
+    name: 'Go gym',
+    startDate: '2021-01-01', // This is a Friday
+    daysOfWeek: ['mon', 'tue', 'thu'],
+  };
 
+  const newHabit1 = new Habit(habit1)
+  await newHabit1.save()
+  const newHabit2 = new Habit(habit2)
+  await newHabit2.save()
+  //await habitColl.insertMany([habit1, habit2]);
+
+  //const textWidget = await Widget.find({type: 'text'})
+  //const textColl = await mongoose.connection.db.createCollection('texts');
+  text1 = {
+    text: 'text1',
+    widgetId: newWidget3._id // maybe just widget3._id
+  };
+  const newText1 = new Text(text1)
+  await newText1.save()
+  //await textColl.insertMany([text1]);
+
+  //const todoColl = await mongoose.connection.db.createCollection('todo_tasks');
+  todo1 = {
+    name: 'test1',
+    createdDate: '2021-01-01',
+    dueDate: '2021-01-01',
+    completed: true
+  };
+  todo2 = {
+    name: 'test2',
+    createdDate: '2020-01-01',
+    dueDate: '2021-01-01',
+    completed: false
+  };
+  todo3 = {
+    name: 'test3',
+    createdDate: '2021-01-01',
+    dueDate: '2023-01-01',
+    completed: true
+  };
+  todo4 = {
+    name: 'test3',
+    createdDate: '2020-01-01',
+    dueDate: '2023-01-01',
+    completed: false
+  };
+  const newTodo1 = new Todo(todo1)
+  await newTodo1.save()
+  const newTodo2 = new Todo(todo2)
+  await newTodo2.save()
+  const newTodo3 = new Todo(todo3)
+  await newTodo3.save()
+  const newTodo4 = new Todo(todo4)
+  await newTodo4.save()
+  //await todoColl.insertMany([todo1, todo2]);
 });
 
 afterEach(async () => {
@@ -76,9 +173,46 @@ afterAll((done) => {
     done();
   });
 });
-
+// Post for text
+// delete for text
 it('Can post to create a new widget and receive widget data in response', async () => {
+    const body = {
+        date: '2021-01-01',
+        position: {
+            row: 1,
+            col: 1,
+        },
+        type: 'calendar'
+      };
+    const response = await axios.post(`http://localhost:${port}/api/journal`, body);
+    const returnData = response.data;
+    //console.log(returnData)
+    // calevents = await CalendarEvent.find()
+    // console.log(calevents)
+    
+    //   expect(returnEvent._id).toBeDefined();
+    //   expect(new Date(returnEvent.startTime)).toStrictEqual(new Date(body.startTime));
+    
+    //   // Response same as what is in database.
+    //   const calEvent = await CalendarEvent.findById(returnEvent._id);
+    //   expect(new Date(returnEvent.startTime)).toStrictEqual(calEvent.startTime);
+    //   expect(new Date(returnEvent.endTime)).toStrictEqual(calEvent.endTime);
+    //   expect(returnEvent.name).toBe(calEvent.name);
+});
 
+
+it('Can post to create a new text widget and receive widget data in response', async () => {
+    const body = {
+        date: '2021-02-03',
+        position: {
+            row: 1,
+            col: 1,
+        },
+        type: 'text'
+      };
+    const response = await axios.post(`http://localhost:${port}/api/journal`, body);
+    const returnData = response.data;
+    console.log(returnData)
 });
 
 it('Can PUT to update position of widget', async () => {
@@ -90,5 +224,22 @@ it('Can delete a widget', async () => {
 });
 
 it('Can GET all widgets for a day, with all the widget data for the day', async () => {
+  const response = await axios.get(`http://localhost:${port}/api/journal/2021-01-01`);
+  const returnData = response.data;
+  
+  expect(returnData.widgetData.length).toBe(2)
+  expect(returnData.widgetData.length).toBe(2)
+  //console.log(returnData)
+});
 
+it('Can GET a text widget', async () => {
+  const response = await axios.get(`http://localhost:${port}/api/journal/2021-02-03`);
+  const returnData = response.data;
+  //console.log(returnData)
+});
+
+it('Can GET a habit widget using the no enddate/unlimted option', async () => {
+    const response = await axios.get(`http://localhost:${port}/api/journal/2022-02-07`);
+    const returnData = response.data;
+    //console.log(returnData)
 });

--- a/telos-backend/test/integration/text_api.test.js
+++ b/telos-backend/test/integration/text_api.test.js
@@ -71,10 +71,10 @@ it('can post a text instance', async () => {
   const body = {
     date: '2021-01-01',
     position: {
-        row: 2,
-        col: 2,
+      row: 2,
+      col: 2,
     },
-    type: 'text'
+    type: 'text',
   };
   const response = await axios.post(`http://localhost:${port}/api/journal`, body);
   const returnData = response.data;

--- a/telos-backend/test/integration/text_api.test.js
+++ b/telos-backend/test/integration/text_api.test.js
@@ -66,22 +66,27 @@ afterAll((done) => {
   });
 });
 
+// Text is created through posting to the /api/journal endpoint.
 it('can post a text instance', async () => {
   const body = {
-    text: 'test lorem ipsum',
-    widgetId: 'abcd1e6a0ba62570afcedd3a',
+    date: '2021-01-01',
+    position: {
+        row: 2,
+        col: 2,
+    },
+    type: 'text'
   };
-  const response = await axios.post(`http://localhost:${port}/api/text`, body);
+  const response = await axios.post(`http://localhost:${port}/api/journal`, body);
   const returnData = response.data;
 
-  expect(returnData._id).toBeDefined();
-  expect(returnData.text).toBe(body.text);
-  expect(returnData.widgetId).toBe(body.widgetId);
+  expect(returnData.data[0]._id).toBeDefined();
+  expect(returnData.data[0].text).toBe('');
+  expect(returnData.data[0].widgetId).toBe(returnData.widget._id);
 
   // Response same as what is in database.
-  const textData = await Text.findById(returnData._id);
-  expect(returnData.text).toBe(textData.text);
-  expect(returnData.widgetId).toBe(textData.widgetId.toString());
+  const textData = await Text.findById(returnData.data[0]._id);
+  expect(returnData.data[0].text).toBe(textData.text);
+  expect(returnData.data[0].widgetId).toBe(textData.widgetId.toString());
 });
 
 it('Can put text to update it', async () => {


### PR DESCRIPTION
Closes #173 

## Proposed Changes
- Add in the actual implementation for these previously defined endpoints
- Use a similar method of testing to the currently completed endpoints (/calendar, /text)
- Allows getting and posting widget information, so that frontend can make and fetch widget data.
