### PR TITLE
Closes #189: removed console.log from method stubs as it violates ESLint rules

### DIFF
--- a/telos-frontend/src/components/top-bar/TopBar.jsx
+++ b/telos-frontend/src/components/top-bar/TopBar.jsx
@@ -53,12 +53,10 @@ const TopBar = () => {
 
   //   Stub for user button handler
   function userMenuHandler() {
-    console.log('User button clicked');
   }
 
   //   Stub for settings button handler
   function settingsMenuHandler() {
-    console.log('Settings button clicked');
   }
 
   return (

--- a/telos-frontend/src/components/top-bar/TopBar.jsx
+++ b/telos-frontend/src/components/top-bar/TopBar.jsx
@@ -52,12 +52,10 @@ const TopBar = () => {
   }
 
   //   Stub for user button handler
-  function userMenuHandler() {
-  }
+  function userMenuHandler() {}
 
   //   Stub for settings button handler
-  function settingsMenuHandler() {
-  }
+  function settingsMenuHandler() {}
 
   return (
     <div>


### PR DESCRIPTION
Closes #189 

## Proposed Changes

- Removed console.log() occurrences from empty method stubs in TopBar.jsx in `telos-frontend/src/components/top-bar`
- These print statements are not needed, empty method stubs are acceptable
