### PR TITLE
Closes #37: Implemented API endpoints for Habit Tracker

### DIFF
--- a/telos-backend/src/routes/api/habittracker.js
+++ b/telos-backend/src/routes/api/habittracker.js
@@ -1,25 +1,46 @@
 const express = require('express');
+const Habit = require('../../models/habit');
 
 const router = express.Router();
 
+// Note: When posting these habits, they can technically go on for an unlimited time.
+// As a result, we persist the information in a different way from how we return it in
+// the GET /api/journal endpoint to avoid creating a huge number of data points.
 router.post('/', (req, res) => {
-  res.json({
-    endpoint: '/habittracker',
-    request: `POST name: ${req.body.name}, daysOfWeek: ${req.body.daysOfWeek}, start: ${req.body.start}, end: ${req.body.end}, completedDates: ${req.body.completedDates}`,
+  const newHabit = new Habit({
+    name: req.body.name,
+    startDate: req.body.startDate,
+    endDate: req.body.endDate,
+    daysOfWeek: req.body.daysOfWeek,
+    completedDates: req.body.completedDates,
+  });
+  newHabit.save((err) => {
+    if (err) {
+      return res.status(400).json({ error: err });
+    }
+    return res.status(201).json(newHabit);
   });
 });
 
 router.put('/:id', (req, res) => {
-  res.json({
-    endpoint: '/habittracker',
-    request: `PUT id: ${req.params.id}, name: ${req.body.name}, daysOfWeek: ${req.body.daysOfWeek}, start: ${req.body.start}, end: ${req.body.end}, completedDates: ${req.body.completedDates}`,
+  const query = { _id: req.params.id };
+
+  Habit.findOneAndUpdate(query, req.body, (err) => {
+    if (err) {
+      return res.status(400).json({ error: err });
+    }
+    return res.sendStatus(204);
   });
 });
 
 router.delete('/:id', (req, res) => {
-  res.json({
-    endpoint: '/habittracker',
-    request: `DELETE id: ${req.params.id}`,
+  const query = { _id: req.params.id };
+
+  Habit.deleteOne(query, (err) => {
+    if (err) {
+      return res.status(400).json({ error: err });
+    }
+    return res.sendStatus(204);
   });
 });
 

--- a/telos-backend/test/integration/habittracker_api.test.js
+++ b/telos-backend/test/integration/habittracker_api.test.js
@@ -1,0 +1,197 @@
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const mongoose = require('mongoose');
+const axios = require('axios');
+const routes = require('../../src/routes');
+const Habit = require('../../src/models/habit');
+
+let mongod;
+let app;
+let server;
+let habit1;
+let habit2;
+let habit3;
+let port;
+
+beforeAll(async (done) => {
+  mongod = new MongoMemoryServer();
+
+  const connectionString = await mongod.getUri();
+  await mongoose.connect(connectionString, {
+    useNewUrlParser: true,
+    useFindAndModify: false,
+    useUnifiedTopology: true,
+  });
+
+  app = express();
+  app.use(express.json());
+  app.use('/', routes);
+  server = app.listen(0, () => {
+    port = server.address().port;
+    done();
+  });
+});
+
+beforeEach(async () => {
+  const coll = await mongoose.connection.db.createCollection('habits');
+
+  habit1 = {
+    name: 'Test1',
+    startDate: '2021-01-01', // This is a Friday
+    endDate: '2021-01-08',
+    daysOfWeek: ['mon', 'tue', 'fri'],
+    completedDates: ['2021-01-01'],
+  };
+
+  // CompletedDates and endDate are optional fields
+  habit2 = {
+    name: 'Go gym',
+    startDate: '2021-01-01', // This is a Friday
+    daysOfWeek: ['mon', 'tue', 'thu'],
+  };
+
+  // Just using the optional endDate field
+  habit3 = {
+    name: 'Cry about 701',
+    startDate: '2022-01-01', // This is a Saturday
+    endDate: '2022-02-01',
+    daysOfWeek: ['mon', 'tue', 'fri'],
+  };
+
+  await coll.insertMany([habit1, habit2, habit3]);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropCollection('habits');
+});
+
+afterAll((done) => {
+  server.close(async () => {
+    await mongoose.disconnect();
+    await mongod.stop();
+
+    done();
+  });
+});
+
+// Text is created through posting to the /api/journal endpoint.
+it('Can post a habit with all fields', async () => {
+  const body = {
+    name: 'My habit',
+    startDate: '2021-02-02', // This is a Tuesday
+    endDate: '2021-03-02',
+    daysOfWeek: ['mon', 'tue', 'fri'],
+    completedDates: ['2021-01-01'],
+  };
+  const response = await axios.post(`http://localhost:${port}/api/habittracker`, body);
+  const returnData = response.data;
+
+  expect(returnData._id).toBeDefined();
+  expect(returnData.name).toBe(body.name);
+  // Returned will be with 'T00:00:00.000Z` appended, as stored as Date object in db
+  expect(new Date(returnData.startDate)).toStrictEqual(new Date(body.startDate));
+  expect(new Date(returnData.endDate)).toStrictEqual(new Date(body.endDate));
+  expect(returnData.daysOfWeek).toStrictEqual(body.daysOfWeek);
+  expect(returnData.completedDates.length).toBe(1);
+  // For same reason above, we need to cast the body.completedDates values to include 'T00:00:00.00z'
+  expect(new Date(returnData.completedDates[0])).toStrictEqual(new Date(body.completedDates[0]));
+
+  // Response same as what is in database.
+  const habitData = await Habit.findById(returnData._id);
+  expect(returnData.name).toBe(habitData.name);
+  expect(new Date(returnData.startDate)).toStrictEqual(new Date(habitData.startDate));
+  expect(new Date(returnData.endDate)).toStrictEqual(new Date(habitData.endDate));
+  // Comparing an Array to CoreMongooseArray, so cast to array via toObject()
+  expect(returnData.daysOfWeek).toStrictEqual(habitData.daysOfWeek.toObject());
+  expect(new Date(returnData.completedDates[0])).toStrictEqual(
+    new Date(habitData.completedDates[0])
+  );
+});
+
+it('Can post a habit with empty completedDates, and no endTime', async () => {
+  const body = {
+    name: 'My habit',
+    startDate: '2021-02-02', // This is a Tuesday
+    daysOfWeek: ['mon', 'tue', 'fri'],
+    completedDates: [],
+  };
+  const response = await axios.post(`http://localhost:${port}/api/habittracker`, body);
+  const returnData = response.data;
+  console.log(returnData);
+
+  expect(returnData._id).toBeDefined();
+  expect(returnData.name).toBe(body.name);
+  // Returned will be with 'T00:00:00.000Z` appended, as stored as Date object in db
+  expect(new Date(returnData.startDate)).toStrictEqual(new Date(body.startDate));
+  // Default undefined end date is new Date(8640000000000000), or '+275760-09-13T00:00:00.000Z'
+  expect(new Date(returnData.endDate)).toStrictEqual(new Date(8640000000000000));
+  expect(returnData.daysOfWeek).toStrictEqual(body.daysOfWeek);
+  expect(returnData.completedDates.length).toBe(0);
+
+  // Response same as what is in database.
+  const habitData = await Habit.findById(returnData._id);
+  expect(returnData.name).toBe(habitData.name);
+  expect(new Date(returnData.startDate)).toStrictEqual(new Date(habitData.startDate));
+  expect(new Date(returnData.endDate)).toStrictEqual(new Date(habitData.endDate));
+  // Comparing an Array to CoreMongooseArray, so cast to array via toObject(). Should be empty.
+  expect(returnData.daysOfWeek).toStrictEqual(habitData.daysOfWeek.toObject());
+});
+
+it('Can put to update a habit', async () => {
+  let habitData = await Habit.findById(habit1._id);
+  expect(habitData.name).toBe(habit1.name);
+  expect(habitData.startDate).toStrictEqual(new Date(habit1.startDate));
+  expect(habitData.endDate).toStrictEqual(new Date(habit1.endDate));
+  expect(habitData.daysOfWeek.toObject()).toStrictEqual(habit1.daysOfWeek);
+  expect(habitData.completedDates.length).toBe(1);
+
+  // Same info as habit1, but with daysOfWeek and completedDates changed
+  await axios.put(`http://localhost:${port}/api/habittracker/${habit1._id}`, {
+    name: 'Test1',
+    startDate: '2021-01-01',
+    endDate: '2021-01-08',
+    daysOfWeek: ['mon', 'tue', 'fri', 'sat', 'sun'],
+    completedDates: ['2021-01-01', '2021-01-02'],
+  });
+
+  // Check the start/endDates and name are the same.
+  habitData = await Habit.findById(habit1._id);
+  expect(habitData.name).toBe(habit1.name);
+  expect(habitData._id).toStrictEqual(habit1._id);
+  expect(habitData.startDate).toStrictEqual(new Date(habit1.startDate));
+  expect(habitData.endDate).toStrictEqual(new Date(habit1.endDate));
+
+  // Different days of week and completedDates
+  expect(habitData.daysOfWeek.toObject()).toStrictEqual(['mon', 'tue', 'fri', 'sat', 'sun']);
+  expect(habitData.completedDates.length).toBe(2);
+  expect(new Date(habitData.completedDates[0])).toStrictEqual(new Date(habit1.completedDates[0]));
+  expect(new Date(habitData.completedDates[1])).toStrictEqual(new Date('2021-01-02T00:00:00.000Z'));
+});
+
+it('Can delete a habit', async () => {
+  const habitsBeforeDelete = await Habit.find();
+  expect(habitsBeforeDelete.length).toBe(3);
+
+  await axios.delete(`http://localhost:${port}/api/habittracker/${habit1._id}`);
+  const habitData = await Habit.find();
+
+  expect(habitData.length).toBe(2);
+
+  // Check habit2 is the same
+  expect(habitData[0].name).toBe(habit2.name);
+  expect(habitData[0]._id).toStrictEqual(habit2._id);
+
+  // Check habit3 is the same
+  expect(habitData[1].name).toBe(habit3.name);
+  expect(habitData[1]._id).toStrictEqual(habit3._id);
+});
+
+it('GET not defined', async () => {
+  let err;
+  try {
+    await axios.get(`http://localhost:${port}/api/habittracker`);
+  } catch (error) {
+    err = error;
+  }
+  expect(err).toBeDefined();
+});

--- a/telos-backend/test/integration/habittracker_api.test.js
+++ b/telos-backend/test/integration/habittracker_api.test.js
@@ -117,7 +117,6 @@ it('Can post a habit with empty completedDates, and no endTime', async () => {
   };
   const response = await axios.post(`http://localhost:${port}/api/habittracker`, body);
   const returnData = response.data;
-  console.log(returnData);
 
   expect(returnData._id).toBeDefined();
   expect(returnData.name).toBe(body.name);


### PR DESCRIPTION
Closes #37

## Proposed Changes
- Added the agreed upon implementation for the habit tracker widget, like the previous implemented endpoints. 
- One issue that came up would be a `PUT` request needs to return all the `completedDates` data along with the new dates to add, which might be problematic if there are many dates to send and return. For now, this is acceptable, but might need some changes for efficiency later eg. a separate completedDatesToAdd field that can be sent on the request body of PUTs.
- Tests implemented to catch issues when refactoring, and ensure endpoints working and ones which aren't defined will not return anything.
