### PR TITLE
Closes #206: Bug fix font change text widget

### DIFF
--- a/telos-frontend/src/components/text/TextWidget.module.css
+++ b/telos-frontend/src/components/text/TextWidget.module.css
@@ -5,6 +5,8 @@
   background-color: transparent;
   border: none;
   outline: none;
+
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }
 
 .box {

--- a/telos-frontend/src/components/text/TextWidget.module.css
+++ b/telos-frontend/src/components/text/TextWidget.module.css
@@ -5,7 +5,6 @@
   background-color: transparent;
   border: none;
   outline: none;
-
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }
 


### PR DESCRIPTION
Closes #206

## Proposed Changes

- Applied the same font family as is used for the body elements (textarea overrode this to monospace)
- In future, it may be good if a global font system can be established to unify the code, however, these changes solve the bug.
