### PR TITLE
Changed styling of Dashboard Todo to better match Journal Todo

### DIFF
--- a/telos-frontend/src/components/todo/DashboardTodo.jsx
+++ b/telos-frontend/src/components/todo/DashboardTodo.jsx
@@ -41,6 +41,10 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexWrap: 'wrap',
   },
+  button: {
+    color: '#6200ee',
+    fontWeight: 'bold',
+  },
   datetextField: {
     marginRight: theme.spacing(1),
   },
@@ -48,6 +52,7 @@ const useStyles = makeStyles((theme) => ({
 
 const outdated = {
   color: 'red',
+  fontWeight: 'Bold',
 };
 
 const DashboardTodo = () => {
@@ -133,7 +138,7 @@ const DashboardTodo = () => {
     setOpen(true);
   };
 
-  const closeAdd = () => {
+  const handleClose = () => {
     setAnchorEl(null);
     setOpen(false);
   };
@@ -255,7 +260,7 @@ const DashboardTodo = () => {
                 <ListItemIcon>
                   {/* Overdue checkbox properties */}
                   <Checkbox
-                    className={styles.checkbox}
+                    className={styles.checkboxOverdue}
                     edge="start"
                     color="primary"
                     checked={todo.completed}
@@ -270,6 +275,7 @@ const DashboardTodo = () => {
                 // If it is not cancelled, text will appear as normal
                 <ListItemText
                   id={labelId}
+                  primaryTypographyProps={{ style: { fontWeight: 'bold' } }}
                   primary={` ${todo.name}`}
                   secondary={` ${todo.due}`}
                   style={{
@@ -350,7 +356,7 @@ const DashboardTodo = () => {
                 </IconButton>
                 {/* The modal that will be displayed for the user to input their description and due date 
                   User input is stored and added into the new item list */}
-                <Dialog open={open} onClose={closeAdd} aria-labelledby="form-dialog-title">
+                <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
                   <DialogTitle id="form-dialog-title">New To Do</DialogTitle>
                   <DialogContent>
                     <form className={classes.datecontainer} noValidate>
@@ -382,7 +388,7 @@ const DashboardTodo = () => {
                   {/* Button to for the user to cancel or Confirm
                   If the user confirms, the date and description will be set. If the user cancels then nothing will be set */}
                   <DialogActions>
-                    <Button className={classes.button} onClick={closeAdd}>
+                    <Button className={classes.button} onClick={handleClose}>
                       Cancel
                     </Button>
                     <Button
@@ -391,7 +397,7 @@ const DashboardTodo = () => {
                       // Once either buttons has been pressed then the modal will close to show other components
                       onClick={() => {
                         secondEvent();
-                        closeAdd();
+                        handleClose();
                       }}
                     >
                       Confirm

--- a/telos-frontend/src/components/todo/DashboardTodo.jsx
+++ b/telos-frontend/src/components/todo/DashboardTodo.jsx
@@ -281,6 +281,7 @@ const DashboardTodo = () => {
                   style={{
                     textDecorationLine: cancel.indexOf(todo.name) !== -1 ? 'line-through' : '',
                     textDecorationStyle: cancel.indexOf(todo.name) !== -1 ? 'solid' : '',
+                    color: todo.completed ? 'rgba(98,0,238,1)' : 'rgba(0, 0, 0, 0.6)',
                   }}
                 />
               ) : (
@@ -290,7 +291,6 @@ const DashboardTodo = () => {
                   style={{
                     textDecorationLine: cancel.indexOf(todo.name) !== -1 ? 'line-through' : '',
                     textDecorationStyle: cancel.indexOf(todo.name) !== -1 ? 'solid' : '',
-                    color: todo.completed ? 'rgba(98,0,238,1)' : 'rgba(0, 0, 0, 0.6)',
                   }}
                   id={labelId}
                   primary={` ${todo.name}`}

--- a/telos-frontend/src/components/todo/DashboardTodo.module.css
+++ b/telos-frontend/src/components/todo/DashboardTodo.module.css
@@ -33,6 +33,10 @@
   color: #828282 !important;
 }
 
+.checkboxOverdue {
+  color: #eb5757 !important;
+}
+
 .outdated {
   color: red !important;
 }


### PR DESCRIPTION
Partially Closes #118 

## Proposed Changes

All to match the original design + JournalTodo
- Text turns purple when a task is approved
- Font bolded to match the original design
- Checkbox red for overdue tasks

How journal to do looks now:
![image](https://user-images.githubusercontent.com/41172492/112382843-38d0af80-8d51-11eb-9b10-cc6da09fbf92.png)
How dashboard to do now looks:
![image](https://user-images.githubusercontent.com/41172492/112383906-9ca7a800-8d52-11eb-8b0d-c686055d78a3.png)

How Dashboard to do previously looked:
![image](https://user-images.githubusercontent.com/41172492/112384084-d7a9db80-8d52-11eb-8652-52e90c7117af.png)

