### PR TITLE
Fixed WidgetCalendar typo

### DIFF
--- a/telos-frontend/src/components/calendar/WidgetCalendar.jsx
+++ b/telos-frontend/src/components/calendar/WidgetCalendar.jsx
@@ -2,7 +2,7 @@ import moment from 'moment';
 import widgetStyles from '../Widget.module.css';
 import calendarWidgetStyles from './WidgetCalendar.module.css';
 
-const WidgetTodo = ({ addNewCalendar }) => {
+const WidgetCalendar = ({ addNewCalendar }) => {
   const today = moment();
   const thisMonth = today.format('MMMM');
   const thisDay = today.format('DD');
@@ -15,4 +15,4 @@ const WidgetTodo = ({ addNewCalendar }) => {
   );
 };
 
-export default WidgetTodo;
+export default WidgetCalendar;

--- a/telos-frontend/src/components/calendar/WidgetCalendar.test.js
+++ b/telos-frontend/src/components/calendar/WidgetCalendar.test.js
@@ -1,0 +1,14 @@
+import { fireEvent, render, cleanup } from '@testing-library/react';
+import WidgetCalendar from './WidgetCalendar';
+
+afterEach(cleanup);
+
+test('Testing the WidgetCalendar', () => {
+  const { asFragment, container } = render(<WidgetCalendar />);
+
+  expect(asFragment(<WidgetCalendar />)).toMatchSnapshot();
+
+  fireEvent.click(container.firstChild);
+
+  expect(container.firstChild).toHaveClass('widgetIcon vertical');
+});

--- a/telos-frontend/src/components/calendar/__snapshots__/WidgetCalendar.test.js.snap
+++ b/telos-frontend/src/components/calendar/__snapshots__/WidgetCalendar.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing the WidgetCalendar 1`] = `
+<DocumentFragment>
+  <div
+    class="widgetIcon vertical"
+  >
+    <div
+      class="smallMonth"
+    >
+      April
+    </div>
+    <div
+      class="bigText"
+    >
+      06
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/telos-frontend/src/components/calendar/__snapshots__/WidgetCalendar.test.js.snap
+++ b/telos-frontend/src/components/calendar/__snapshots__/WidgetCalendar.test.js.snap
@@ -13,7 +13,7 @@ exports[`Testing the WidgetCalendar 1`] = `
     <div
       class="bigText"
     >
-      06
+      07
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
Closes #165 

## Proposed Changes

- Replaced `WidgetTodo` with `WidgetCalendar` twice in `WidgetCalendar.jsx`
- Added the frontend snapshot test of the WidgetCalendar
- Unsure of whether or not I should make tests for the other calendar components (??)
- Unsure of where to keep these tests in the file structure