### PR TITLE
YouTube widgets resize was misplaced when generating a widget #281

### DIFF
--- a/telos-frontend/src/components/youtube-player/JournalYoutubePlayer.module.css
+++ b/telos-frontend/src/components/youtube-player/JournalYoutubePlayer.module.css
@@ -10,7 +10,9 @@
 .ytWidget {
 resize: both;
 overflow: hidden visible;
-min-height: 350px;
+height: 240px;
+width: 360px;
+min-height: 240px;
 min-width: 360px;
 }
 
@@ -39,5 +41,5 @@ box-sizing: border-box;
 iframe {
   display: block;
   width: 100%;
-  height: 80%;
+  height: 70%;
 }


### PR DESCRIPTION
Fixed the error where the resize tool was well below the actual size of the iframe.

Added explicit height and width to resolve this bug.