### PR TITLE
Adding a field to provide the Steam name

### DIFF
--- a/telos-backend/src/routes/api/steam.js
+++ b/telos-backend/src/routes/api/steam.js
@@ -11,7 +11,7 @@ set STEAM_KEY= <your steam key>
 e.g set STEAM_KEY=78D5D2BFF2B1C517MKDS9809F
 More information on: https://github.com/UOA-SE701-Group3-2021/3Lancers/pull/287
 * */
-const steamKey = '78D5D2BFF2B1C517C1B77B91F919862F';
+const steamKey = process.env.STEAM_KEY;
 
 /**
  * Filter the unwanted fields from the steam data & sort by playtime

--- a/telos-backend/src/routes/api/steam.js
+++ b/telos-backend/src/routes/api/steam.js
@@ -11,7 +11,7 @@ set STEAM_KEY= <your steam key>
 e.g set STEAM_KEY=78D5D2BFF2B1C517MKDS9809F
 More information on: https://github.com/UOA-SE701-Group3-2021/3Lancers/pull/287
 * */
-const steamKey = process.env.STEAM_KEY;
+const steamKey = '78D5D2BFF2B1C517C1B77B91F919862F';
 
 /**
  * Filter the unwanted fields from the steam data & sort by playtime

--- a/telos-frontend/src/components/steam/steam.jsx
+++ b/telos-frontend/src/components/steam/steam.jsx
@@ -32,6 +32,7 @@ const Steam = () => {
   const [data, setData] = useState();
   const [dataMessage, setDataMessage] = useState('Please provide username...');
   const [steamName, setSteamName] = useState('');
+  const [getSteam, setGetSteam] = useState(false);
 
   useEffect(() => {
     const getSteamData = async (userId) => {
@@ -49,7 +50,7 @@ const Steam = () => {
     if (loadingData) {
       getSteamData(steamName);
     }
-  }, [steamName]);
+  }, [getSteam]);
 
   const setSteam = (newName) => {
     setSteamName(newName);
@@ -57,6 +58,10 @@ const Steam = () => {
   const NoDataColumn = [
     { field: 'StatusNow', headerName: `Status: ${dataMessage}`, width: 600, sortable: false },
   ];
+
+  const onSubmit = () => {
+    setGetSteam(true);
+  };
 
   const NoDataRows = [
     {
@@ -89,25 +94,38 @@ const Steam = () => {
   ];
 
   return (
-    <div style={{ height: 400, width: '100%' }}>
-      {loadingData ? (
-        <>
-          <DataGrid className={classes.NoDataTable} rows={NoDataRows} columns={NoDataColumn} />
-
-          <p>
-            {dataMessage}{' '}
+    <>
+      {!getSteam ? (
+        <div>
+          <form onSubmit={onSubmit}>
             <input
               onChange={(e) => setSteam(e.target.value)}
               type="text"
               id="steamName"
               name="steamName"
             />
-          </p>
-        </>
+            <input type="submit" value="View Account!" />
+          </form>
+        </div>
       ) : (
-        <DataGrid className={classes.table} rows={data} columns={steamColumns} checkboxSelection />
+        <div style={{ height: 400, width: '100%' }}>
+          {loadingData ? (
+            <>
+              <DataGrid className={classes.NoDataTable} rows={NoDataRows} columns={NoDataColumn} />
+
+              <p>{dataMessage} </p>
+            </>
+          ) : (
+            <DataGrid
+              className={classes.table}
+              rows={data}
+              columns={steamColumns}
+              checkboxSelection
+            />
+          )}
+        </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/telos-frontend/src/components/steam/steam.jsx
+++ b/telos-frontend/src/components/steam/steam.jsx
@@ -5,7 +5,6 @@ import { makeStyles } from '@material-ui/core/styles';
 
 // Add in your steam name
 // More information on: https://github.com/UOA-SE701-Group3-2021/3Lancers/pull/287
-const steamName = 'SteamName';
 
 const steamColumns = [
   { field: 'name', headerName: 'Game', width: 200 },
@@ -24,7 +23,9 @@ const Steam = () => {
   const classes = useStyles();
   const [loadingData, setLoadingData] = useState(true);
   const [data, setData] = useState();
-  const [dataMessage, setDataMessage] = useState('Loading steam data...');
+  const [dataMessage, setDataMessage] = useState('Please provide username...');
+  const [steamName, setSteamName] = useState('');
+
   useEffect(() => {
     const getSteamData = async (userId) => {
       await axios.get(`/api/steam?steamVanity=${userId}`).then((response) => {
@@ -41,12 +42,26 @@ const Steam = () => {
     if (loadingData) {
       getSteamData(steamName);
     }
-  }, []);
+  }, [steamName]);
+
+  const setSteam = (newName) => {
+    setSteamName(newName);
+  };
 
   return (
     <div style={{ height: 400, width: '100%' }}>
       {loadingData ? (
-        <p>{dataMessage}</p>
+        <>
+          <p>
+            {dataMessage}{' '}
+            <input
+              onChange={(e) => setSteam(e.target.value)}
+              type="text"
+              id="steamName"
+              name="steamName"
+            />
+          </p>
+        </>
       ) : (
         <DataGrid
           className={classes.table}

--- a/telos-frontend/src/components/steam/steam.jsx
+++ b/telos-frontend/src/components/steam/steam.jsx
@@ -96,13 +96,14 @@ const Steam = () => {
   return (
     <>
       {!getSteam ? (
-        <div>
+        <div style={{ height: 400, width: '40%' }}>
           <form onSubmit={onSubmit}>
             <input
               onChange={(e) => setSteam(e.target.value)}
               type="text"
               id="steamName"
               name="steamName"
+              placeholder="Put username here"
             />
             <input type="submit" value="View Account!" />
           </form>
@@ -113,7 +114,9 @@ const Steam = () => {
             <>
               <DataGrid className={classes.NoDataTable} rows={NoDataRows} columns={NoDataColumn} />
 
-              <p>{dataMessage} </p>
+              <button type="button" onClick={() => setGetSteam(false)}>
+                Try again{' '}
+              </button>
             </>
           ) : (
             <DataGrid


### PR DESCRIPTION
Closes #292 

## Proposed Changes
- Added a new state to allow the user to provide their Steam name
- Allows the user to try again if the name fails

Just to note, some extra work may be to style it to look more pleasant, or to add a short delay as it briefly shows the error state even on a successful response.
